### PR TITLE
Fix Railway deployment

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -16,7 +16,7 @@ files = [
 name = "bcrypt"
 version = "4.3.0"
 description = "Modern password hashing for your software and your servers"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -82,7 +82,7 @@ typecheck = ["mypy"]
 name = "blinker"
 version = "1.9.0"
 description = "Fast, simple object-to-object and broadcast signaling"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -209,7 +209,7 @@ files = [
 name = "click"
 version = "8.2.1"
 description = "Composable command line interface toolkit"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -254,7 +254,7 @@ profile = ["gprof2dot (>=2022.7.29)"]
 name = "dnspython"
 version = "2.7.0"
 description = "DNS toolkit"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"apps\" or extra == \"full\""
@@ -276,7 +276,7 @@ wmi = ["wmi (>=1.5.1)"]
 name = "flask"
 version = "3.1.1"
 description = "A simple framework for building complex web applications."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -301,7 +301,7 @@ dotenv = ["python-dotenv"]
 name = "gunicorn"
 version = "21.2.0"
 description = "WSGI HTTP Server for UNIX"
-optional = true
+optional = false
 python-versions = ">=3.5"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -354,7 +354,7 @@ plugins = ["setuptools"]
 name = "itsdangerous"
 version = "2.2.0"
 description = "Safely pass data to untrusted environments and back."
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -367,7 +367,7 @@ files = [
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
-optional = true
+optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -386,7 +386,7 @@ i18n = ["Babel (>=2.7)"]
 name = "markupsafe"
 version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -470,7 +470,7 @@ files = [
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -500,7 +500,7 @@ type = ["mypy (>=1.14.1)"]
 name = "psycopg2-binary"
 version = "2.9.10"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -604,7 +604,7 @@ testutils = ["gitpython (>3)"]
 name = "pymongo"
 version = "4.13.2"
 description = "PyMongo - the Official MongoDB Python driver"
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"apps\" or extra == \"full\""
@@ -737,7 +737,7 @@ zstd = ["zstandard (>=0.18.0)"]
 name = "werkzeug"
 version = "3.1.3"
 description = "The comprehensive WSGI web application library."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"vault\" or extra == \"apps\" or extra == \"full\""
@@ -760,4 +760,4 @@ vault = ["bcrypt", "flask", "gunicorn", "psycopg2-binary", "werkzeug"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11.0,<3.12"
-content-hash = "251c01e1ad73e4b82c9926ea66985d61fa32a76ec999ebdcaef59a4d95645fa3"
+content-hash = "db22f30dbf5c1ab58311e0c94e3a09ff4b1ab7dbb4a2ea3f50d2fdcb081c7408"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ python = ">=3.11.0,<3.12"
 # Client library dependencies (minimal for HTTP requests)
 requests = "^2.32.4"
 
-# Deployment orchestration dependencies (all services)
-flask = {version = "^3.0.0", optional = true}
-bcrypt = {version = "^4.2.1", optional = true}
-psycopg2-binary = {version = "^2.9.0", optional = true}
-pymongo = {extras = ["srv"], version = "^4.13.2", optional = true}
-gunicorn = {version = "^21.2.0", optional = true}
-werkzeug = {version = "^3.0.0", optional = true}
+# Deployment orchestration dependencies (all services) - required for deployment
+flask = "^3.0.0"
+bcrypt = "^4.2.1"
+psycopg2-binary = "^2.9.0"
+pymongo = {extras = ["srv"], version = "^4.13.2"}
+gunicorn = "^21.2.0"
+werkzeug = "^3.0.0"
 
 [tool.poetry.extras]
 # Optional dependency groups for deployment modes


### PR DESCRIPTION
Make optional dependencies in root pyproject.toml required.

This is a temporary hack to get the deployment working; preferred end state is to only build and deploy apps or vault.