### PR TITLE
feat: add /admin routes to the Campus API

### DIFF
--- a/campus/apps/api/__init__.py
+++ b/campus/apps/api/__init__.py
@@ -35,6 +35,7 @@ def init_app(app: Flask | Blueprint) -> None:
     routes.circles.init_app(bp)
     routes.emailotp.init_app(bp)
     routes.users.init_app(bp)
+    routes.admin.init_app(bp)
     app.register_blueprint(bp)
 
 

--- a/campus/apps/api/__init__.py
+++ b/campus/apps/api/__init__.py
@@ -40,6 +40,7 @@ def init_app(app: Flask | Blueprint) -> None:
 
 
 @devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def init_db() -> None:
     """Initialise the tables needed by api.
 
@@ -48,17 +49,16 @@ def init_db() -> None:
     """
     # These imports do not appear at the top of the file to avoid namespace
     # pollution, as they are typically only used in staging.
-    from campus.models import emailotp, user
-    from campus.vault import client
+    from campus import models, vault
 
-    for model in (emailotp, user):
-        model.init_db()
-
-    # Initialize vault client database
-    client.init_db()
+    models.circle.init_db()
+    models.emailotp.init_db()
+    models.user.init_db()
+    vault.client.init_db()
 
 
 @devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def purge() -> None:
     """Purge the database.
 
@@ -67,13 +67,5 @@ def purge() -> None:
     """
     # These imports do not appear at the top of the file to avoid namespace
     # pollution, as they are typically not used in production.
-    from warnings import warn  # type: ignore[import-untyped]
     from campus.storage import purge_all  # type: ignore[import-untyped]
-
-    if devops.ENV == devops.STAGING:
-        warn(f"Purging database in {devops.ENV} environment.", stacklevel=2)
-        if input("Are you sure? (y/n): ").lower() == 'y':
-            # User confirmed the purge
-            purge_all()
-    else:
-        purge_all()
+    purge_all()

--- a/campus/apps/api/routes/__init__.py
+++ b/campus/apps/api/routes/__init__.py
@@ -3,10 +3,11 @@
 This is a namespace module for the Campus API routes.
 """
 
-from . import circles, emailotp, users
+from . import circles, emailotp, users, admin
 
 __all__ = [
     "circles",
     "emailotp",
     "users",
+    "admin",
 ]

--- a/campus/apps/api/routes/admin.py
+++ b/campus/apps/api/routes/admin.py
@@ -1,0 +1,21 @@
+"""apps.api.routes.admin
+
+Admin routes for Campus API.
+"""
+
+from flask import Blueprint
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+# Example route
+
+
+@bp.route("/status", methods=["GET"])
+def status():
+    """Return admin status info."""
+    return {"status": "ok", "message": "Admin endpoint is live."}
+
+
+def init_app(app):
+    """Register the admin blueprint with the given Flask app or blueprint."""
+    app.register_blueprint(bp)

--- a/campus/common/devops/__init__.py
+++ b/campus/common/devops/__init__.py
@@ -6,7 +6,7 @@ This module contains the DevOps-related functionality for the Campus project.
 import os
 from functools import wraps
 from typing import Literal
-
+from warnings import warn
 
 # typing stub
 Env = Literal["development", "testing", "staging", "production"]
@@ -27,21 +27,6 @@ assert ENV in (
 ), f"Invalid environment: {ENV}"
 
 
-def require_env(*envs: str):
-    """Decorator to require specified environments for function execution.
-    """
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            if ENV not in envs:
-                raise RuntimeError(
-                    f"ENV={ENV}: {func.__name__}() requires {envs} environment."
-                )
-            return func(*args, **kwargs)
-        return wrapper
-    return decorator
-
-
 def block_env(*envs: str):
     """Decorator to block function execution in specified environments.
     """
@@ -51,6 +36,42 @@ def block_env(*envs: str):
             if ENV in envs:
                 raise RuntimeError(
                     f"ENV={ENV}: {func.__name__}() cannot be called in {envs} environment."
+                )
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def confirm_action_in_env(*envs, prompt: str = "Proceed? (y/N): "):
+    """
+    Decorator to require user confirmation before executing a function in specified environments.
+    If the current environment matches one of the specified envs, prompt the user before running.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if ENV in envs:
+                warn(f"Calling {func.__name__}() in {ENV} environment.", stacklevel=2)
+                if input(prompt).lower() == 'y':
+                    return func(*args, **kwargs)
+                else:
+                    print("Action cancelled.")
+                    return None
+            else:
+                return func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def require_env(*envs: str):
+    """Decorator to require specified environments for function execution.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if ENV not in envs:
+                raise RuntimeError(
+                    f"ENV={ENV}: {func.__name__}() requires {envs} environment."
                 )
             return func(*args, **kwargs)
         return wrapper

--- a/campus/storage/__init__.py
+++ b/campus/storage/__init__.py
@@ -7,6 +7,8 @@ Two kinds of storage interface are provided:
 2. Documents: For storing documents that can have different schemas.
 """
 
+from campus.common import devops
+
 from . import documents, tables
 
 from .documents import CollectionInterface
@@ -24,6 +26,8 @@ def get_collection(name: str):
     return documents.get_db(name)
 
 
+@devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def purge_tables() -> None:
     """Purge all tables in the database.
 
@@ -37,6 +41,8 @@ def purge_tables() -> None:
     _purge_tables()
 
 
+@devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def purge_collections() -> None:
     """Purge all collections in the database.
 
@@ -50,6 +56,8 @@ def purge_collections() -> None:
     _purge_collections()
 
 
+@devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def purge_all() -> None:
     """Purge all tables and collections.
 


### PR DESCRIPTION
This PR adds:

- `/admin` route and endpoints to `campus.apps.api`
- improvements to the `campus.devops` module: adds a `confirm_action_in_env()` decorator