### PR TITLE
Bugfix: handling meta documents in storage.documents mongodb backend

### DIFF
--- a/campus/models/circle.py
+++ b/campus/models/circle.py
@@ -54,7 +54,13 @@ def init_db():
     # Ensure meta record exists
     meta_list = storage.get_matching({"@meta": True})
     if not meta_list:
-        storage.insert_one({"@meta": True})
+        # The meta document id is unused but required by the
+        # storage interface
+        storage.insert_one({
+            "id": uid.generate_category_uid("meta", length=8),
+            "created_at": utc_time.now(),
+            "@meta": True
+        })
         meta_list = storage.get_matching({"@meta": True})
     meta_record = meta_list[0]
 

--- a/campus/models/circle.py
+++ b/campus/models/circle.py
@@ -52,8 +52,8 @@ def init_db():
     storage.init_collection()
 
     # Ensure meta record exists
-    meta_list = storage.get_matching({"@meta": True})
-    if not meta_list:
+    meta_record = get_circle_meta()
+    if not meta_record:
         # The meta document id is unused but required by the
         # storage interface
         storage.insert_one({
@@ -61,8 +61,7 @@ def init_db():
             "created_at": utc_time.now(),
             "@meta": True
         })
-        meta_list = storage.get_matching({"@meta": True})
-    meta_record = meta_list[0]
+        meta_record = get_circle_meta()
 
     # Check for existing root circle
     if not "root" not in meta_record or not meta_record["root"]:

--- a/campus/models/circle.py
+++ b/campus/models/circle.py
@@ -169,7 +169,7 @@ def get_circle_meta() -> "CircleMeta":
 
 
 def get_root_circle() -> "CircleRecord":
-    """Get the root circle ID from the settings collection."""
+    """Get the root circle."""
     circle_meta = get_circle_meta()
     if "root" not in circle_meta:
         raise api_errors.InternalError(

--- a/campus/models/circle.py
+++ b/campus/models/circle.py
@@ -64,7 +64,7 @@ def init_db():
         meta_record = get_circle_meta()
 
     # Check for existing root circle
-    if not "root" not in meta_record or not meta_record["root"]:
+    if "root" not in meta_record or not meta_record["root"]:
         # Create admin and root circles
         root_circle = Circle().new(
             name=DOMAIN,

--- a/campus/storage/documents/backend/mongodb.py
+++ b/campus/storage/documents/backend/mongodb.py
@@ -151,7 +151,7 @@ class MongoDBCollection(CollectionInterface):
     def get_by_id(self, doc_id: str) -> dict:
         """Retrieve a document by its ID."""
         try:
-            record = self.collection.find_one({PK: doc_id})
+            record = self.collection.find_one({MONGO_PK: doc_id})
         except Exception as e:
             raise RuntimeError(f"Failed to retrieve document by id: {e}") from e
         if record:
@@ -191,7 +191,7 @@ class MongoDBCollection(CollectionInterface):
         if not update:
             return
         try:
-            result = self.collection.update_one({PK: doc_id}, {"$set": update})
+            result = self.collection.update_one({MONGO_PK: doc_id}, {"$set": update})
         except Exception as e:
             raise RuntimeError(f"Failed to update document by id: {e}") from e
         if result.matched_count == 0:
@@ -211,7 +211,7 @@ class MongoDBCollection(CollectionInterface):
     def delete_by_id(self, doc_id: str) -> None:
         """Delete a document from the collection."""
         try:
-            result = self.collection.delete_one({PK: doc_id})
+            result = self.collection.delete_one({MONGO_PK: doc_id})
         except Exception as e:
             raise RuntimeError(f"Failed to delete document by id: {e}") from e
         if result.deleted_count == 0:


### PR DESCRIPTION
This PR resolves the issue of init_db() being unable to create the meta document due to missing `id` field.

Fix #167 