### PR TITLE
fix: typo in PK handling in to_mongo()

### DIFF
--- a/campus/storage/documents/backend/mongodb.py
+++ b/campus/storage/documents/backend/mongodb.py
@@ -99,7 +99,7 @@ class MongoRecord(dict):
     def to_mongo(self) -> dict:
         """Convert the MongoRecord to a MongoDB document."""
         mongo_doc = dict(self)
-        mongo_doc[MONGO_PK] = mongo_doc.pop(PK)
+        mongo_doc[PK] = mongo_doc.pop(MONGO_PK)
         return mongo_doc
 
     def to_record(self) -> dict:


### PR DESCRIPTION
This PR fixes the following error during DB init:

```bash
Traceback (most recent call last):
  File "/app/.venv/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
  File "/app/campus/common/devops/__init__.py", line 61, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/campus/apps/api/routes/admin.py", line 25, in init_db
    rv = self.handle_user_exception(e)
    models.circle.init_db()
  File "/app/campus/common/devops/__init__.py", line 40, in wrapper
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    rv = self.dispatch_request()
  File "/app/campus/models/circle.py", line 59, in init_db
    storage.insert_one({
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/campus/storage/documents/backend/mongodb.py", line 182, in insert_one
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
    MongoRecord.from_record(row).to_mongo()
  File "/app/campus/storage/documents/backend/mongodb.py", line 102, in to_mongo
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    mongo_doc[MONGO_PK] = mongo_doc.pop(PK)
                          ^^^^^^^^^^^^^^^^^
  File "/app/campus/common/devops/__init__.py", line 40, in wrapper
KeyError: 'id'
```