### PR TITLE
Add logging calls

### DIFF
--- a/campus/common/errors/__init__.py
+++ b/campus/common/errors/__init__.py
@@ -32,7 +32,7 @@ def handle_api_error(err: APIError) -> tuple[JsonDict, int]:
     """
     module = get_caller()
     logging.getLogger("campus.common.errors").error(
-        "APIError handled in %s: %s\n%s", module, err, traceback.format_exc()
+        "APIError in %s: %s\n%s", module, err, traceback.format_exc()
     )
     return err.to_dict(), err.status_code
 
@@ -47,7 +47,7 @@ def handle_werkzeug_error(err: HTTPException) -> tuple[JsonDict, int]:
     """
     module = get_caller()
     logging.getLogger("campus.common.errors").error(
-        "Werkzeug HTTPException handled in %s: %s\n%s", module, err, traceback.format_exc()
+        "Werkzeug HTTPException in %s: %s\n%s", module, err, traceback.format_exc()
     )
     match err:
         case InternalServerError():


### PR DESCRIPTION
https://github.com/nyjc-computing/campus/blob/51640f8445380b55d3e7c01ea0de64b7784c784d/campus/common/errors/__init__.py#L12-L33

Errors are not showing up in process logs because they are intercepted and an error response is returned.

To resolve this, we need to add logging calls.

This PR adds logging calls, as part of the effort to resolve #198 