### PR TITLE
Refactor deployment structure

### DIFF
--- a/campus/apps/__init__.py
+++ b/campus/apps/__init__.py
@@ -12,20 +12,7 @@ This module contains the main applications for Campus.
 
 from flask import Blueprint, Flask
 
-from campus.common import errors
-
 from . import api, campusauth, oauth
-
-
-def create_app() -> Flask:
-    """Create the main Campus app with all modules"""
-    from campus.client import VaultClient
-    vault = VaultClient()
-    app = Flask(__name__)
-    app.secret_key = vault["campus"]["SECRET_KEY"].get()
-    init_app(app)
-    errors.init_app(app)
-    return app
 
 
 def init_app(app: Blueprint | Flask) -> None:
@@ -39,6 +26,5 @@ __all__ = [
     "api",
     "campusauth",
     "oauth",
-    "create_app",
     "init_app",
 ]

--- a/campus/apps/__init__.py
+++ b/campus/apps/__init__.py
@@ -10,7 +10,7 @@ This module contains the main applications for Campus.
 - oauth: Campus OAuth2 implementation.
 """
 
-from flask import Flask
+from flask import Blueprint, Flask
 
 from campus.common import errors
 
@@ -28,7 +28,7 @@ def create_app() -> Flask:
     return app
 
 
-def init_app(app: Flask) -> None:
+def init_app(app: Blueprint | Flask) -> None:
     """Initialize the Campus app with all modules."""
     api.init_app(app)
     campusauth.init_app(app)

--- a/campus/apps/__init__.py
+++ b/campus/apps/__init__.py
@@ -33,7 +33,6 @@ def init_app(app: Blueprint | Flask) -> None:
     api.init_app(app)
     campusauth.init_app(app)
     oauth.init_app(app)
-    errors.init_app(app)
 
 
 __all__ = [

--- a/campus/apps/api/__init__.py
+++ b/campus/apps/api/__init__.py
@@ -6,23 +6,6 @@ Web API for Campus services.
 from flask import Blueprint, Flask
 
 from campus.apps.api import routes
-from campus.common import errors
-
-__all__ = [
-    'create_app',
-    'init_app',
-]
-
-
-def create_app() -> Flask:
-    """Factory function to create the api app.
-
-    This is called if api is run as a standalone app.
-    """
-    app = Flask(__name__)
-    init_app(app)
-    errors.init_app(app)
-    return app
 
 
 def init_app(app: Flask | Blueprint) -> None:
@@ -36,3 +19,8 @@ def init_app(app: Flask | Blueprint) -> None:
     routes.users.init_app(bp)
     routes.admin.init_app(bp)
     app.register_blueprint(bp)
+
+
+__all__ = [
+    'init_app',
+]

--- a/campus/apps/campusauth/__init__.py
+++ b/campus/apps/campusauth/__init__.py
@@ -13,7 +13,6 @@ from .authentication import (
 )
 
 __all__ = [
-    'create_app',
     'init_app',
     'init_db',
     'authenticate_client',
@@ -21,22 +20,11 @@ __all__ = [
 ]
 
 
-def create_app() -> Flask:
-    """Factory function to create the campusauth app.
-    
-    This is called if campusauth is run as a standalone app.
-    """
-    from campus.common import errors
-    app = Flask(__name__)
-    init_app(app)
-    # TODO: review error handler registration to handle HTML and API errors
-    errors.init_app(app)
-    return app
-
 def init_app(app: Flask | Blueprint) -> None:
     """Initialise the campusauth blueprint with the given Flask app."""
     from . import routes
     routes.init_app(app)
+
 
 @devops.block_env(devops.PRODUCTION)
 def init_db() -> None:

--- a/campus/apps/oauth/__init__.py
+++ b/campus/apps/oauth/__init__.py
@@ -5,28 +5,10 @@ OAuth2 routes for integrations.
 
 from flask import Blueprint, Flask
 
-from campus.common import errors
 from campus.common import devops
 
 from . import google
 
-__all__ = [
-    'create_app',
-    'init_app',
-    'init_db',
-]
-
-
-def create_app() -> Flask:
-    """Factory function to create the oauth app.
-    
-    This is called if oauth is run as a standalone app, without the /oauth
-    url prefix.
-    """
-    app = Flask(__name__)
-    init_app(app)
-    errors.init_app(app)
-    return app
 
 def init_app(app: Flask | Blueprint) -> None:
     """Initialise the oauth blueprint with the given Flask app."""
@@ -35,6 +17,7 @@ def init_app(app: Flask | Blueprint) -> None:
     google.init_app(bp)
     app.register_blueprint(bp)
 
+
 @devops.block_env(devops.PRODUCTION)
 def init_db() -> None:
     """Initialise the tables needed by oauth.
@@ -42,4 +25,10 @@ def init_db() -> None:
     This convenience function makes it easier to initialise tables for all
     models.
     """
+
+
+__all__ = [
+    'init_app',
+    'init_db',
+]
     

--- a/campus/common/devops/__init__.py
+++ b/campus/common/devops/__init__.py
@@ -8,6 +8,9 @@ from functools import wraps
 from typing import Literal
 from warnings import warn
 
+# Namespace exports
+from . import deploy
+
 # typing stub
 Env = Literal["development", "testing", "staging", "production"]
 
@@ -76,3 +79,8 @@ def require_env(*envs: str):
             return func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+__all__ = [
+    "deploy",
+]

--- a/campus/common/devops/__init__.py
+++ b/campus/common/devops/__init__.py
@@ -5,6 +5,7 @@ This module contains the DevOps-related functionality for the Campus project.
 
 import os
 from functools import wraps
+import logging
 from typing import Literal
 from warnings import warn
 
@@ -19,6 +20,9 @@ DEVELOPMENT = "development"
 TESTING = "testing"
 STAGING = "staging"
 PRODUCTION = "production"
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # If not defined, assume development environment
 ENV = os.getenv("ENV", "development")
@@ -58,7 +62,7 @@ def confirm_action_in_env(*envs, prompt: str = "Proceed? (y/N): "):
                 if input(prompt).lower() == 'y':
                     return func(*args, **kwargs)
                 else:
-                    print("Action cancelled.")
+                    logger.info("Action cancelled.")
                     return None
             else:
                 return func(*args, **kwargs)

--- a/campus/common/devops/deploy.py
+++ b/campus/common/devops/deploy.py
@@ -17,7 +17,10 @@ MODES = ("apps", "vault")
 # pylint disable=unnecessary-ellipsis
 
 class AppModule(Protocol):
-    """Interface for app modules."""
+    """Interface for app modules.
+
+    App modules must implement the `init_app` function.
+    """
 
     @staticmethod
     def init_app(app: Flask | Blueprint) -> None:

--- a/campus/vault/__init__.py
+++ b/campus/vault/__init__.py
@@ -83,7 +83,6 @@ __all__ = [
     "get_authenticated_vault",
     "Vault",
     "AuthenticatedVault",
-    "create_app",
     "init_app",
     "init_db",
     "access",
@@ -173,17 +172,6 @@ def get_authenticated_vault(label: str) -> AuthenticatedVault:
     class directly with explicit authentication handling.
     """
     return AuthenticatedVault(label)
-
-
-def create_app() -> Flask:
-    """Factory function to create the vault app.
-
-    This is called if vault is run as a standalone app.
-    """
-    app = Flask(__name__)
-    init_app(app)
-    errors.init_app(app)
-    return app
 
 
 def init_app(app: Flask | Blueprint) -> None:

--- a/campus/vault/__init__.py
+++ b/campus/vault/__init__.py
@@ -188,17 +188,10 @@ def create_app() -> Flask:
 
 def init_app(app: Flask | Blueprint) -> None:
     """Initialize the vault blueprints with the given Flask app."""
-    from .routes import init_vault_routes, init_access_routes, init_client_routes
-
-    # Health check route for deployments
-    @app.route('/')
-    def health_check():
-        return {'status': 'healthy', 'service': 'campus-vault'}, 200
-
-    # Register all vault-related blueprints
-    init_vault_routes(app)   # /vault/* - secret management
-    init_access_routes(app)  # /access/* - access control
-    init_client_routes(app)  # /client/* - client management
+    from . import routes
+    routes.access.init_app(app)
+    routes.client.init_app(app)
+    routes.vault.init_app(app)
 
 
 @devops.block_env(devops.PRODUCTION)

--- a/campus/vault/__init__.py
+++ b/campus/vault/__init__.py
@@ -209,19 +209,3 @@ def init_db():
 
     # Initialize vault client table
     client.init_db()
-
-
-def run_server():
-    """Entry point for running vault as a standalone service"""
-    app = create_app()
-
-    # Replit configuration
-    host = "0.0.0.0"
-    port = 5000
-
-    print(f"🔐 Starting Campus Vault Service on {host}:{port}")
-    app.run(host=host, port=port, debug=False)
-
-
-if __name__ == '__main__':
-    run_server()

--- a/campus/vault/routes/__init__.py
+++ b/campus/vault/routes/__init__.py
@@ -11,19 +11,11 @@ Each module defines a Flask blueprint with appropriate URL prefixes and
 authentication decorators.
 """
 
-from .vault import init_app as init_vault_routes
-from .access import init_app as init_access_routes  
-from .client import init_app as init_client_routes
+from . import access, client, vault
+
 
 __all__ = [
-    "init_vault_routes",
-    "init_access_routes", 
-    "init_client_routes"
+    "access",
+    "client",
+    "vault"
 ]
-
-
-def init_all_routes(app):
-    """Initialize all vault-related routes with the given Flask app."""
-    init_vault_routes(app)
-    init_access_routes(app)
-    init_client_routes(app)

--- a/main.py
+++ b/main.py
@@ -16,8 +16,12 @@ Usage:
 """
 
 import os
+import logging
 
 from campus.common import devops
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def get_deployment_mode():
@@ -43,11 +47,11 @@ def create_app() -> devops.deploy.Flask:
     match mode:
         case "vault":
             import campus.vault
-            print("🔐 Creating Campus Vault Service")
+            logger.info("🔐 Creating Campus Vault Service")
             app = devops.deploy.create_app(campus.vault)
         case "apps":
             import campus.apps
-            print("🚀 Creating Campus Apps Service")
+            logger.info("🚀 Creating Campus Apps Service")
             app = devops.deploy.create_app(campus.apps)
         case _:
             raise ValueError(

--- a/main.py
+++ b/main.py
@@ -17,43 +17,45 @@ Usage:
 
 import os
 
+from campus.common import devops
+
 
 def get_deployment_mode():
     """Get deployment mode from DEPLOY environment variable"""
     if "DEPLOY" not in os.environ:
         raise EnvironmentError(
             "Deployment mode not set. "
-            "Set environment variable: export DEPLOY=vault or export DEPLOY=apps"
+            "Set environment variable: export DEPLOY=<mode>"
         )
     mode = os.environ["DEPLOY"]
-
-    if mode not in ["vault", "apps"]:
+    if mode not in devops.deploy.MODES:
         raise ValueError(
             f"Invalid deployment mode '{mode}'. "
-            "Valid modes are: vault, apps. "
-            "Set environment variable: export DEPLOY=vault or export DEPLOY=apps"
+            f"Valid modes are: {', '.join(devops.deploy.MODES)}."
         )
-
     return mode
 
 
-def create_app():
+def create_app() -> devops.deploy.Flask:
     """Create the appropriate Campus app based on deployment mode"""
     mode = get_deployment_mode()
 
     match mode:
         case "vault":
+            import campus.vault
             print("🔐 Creating Campus Vault Service")
-            from campus.vault import create_app
-            return create_app()
+            app = devops.deploy.create_app(campus.vault)
         case "apps":
+            import campus.apps
             print("🚀 Creating Campus Apps Service")
-            from campus.apps import create_app
-            return create_app()
-    raise ValueError(
-        f"Unsupported deployment mode '{mode}'. "
-        "Valid modes are: vault, apps"
-    )
+            app = devops.deploy.create_app(campus.apps)
+        case _:
+            raise ValueError(
+                f"Unsupported deployment mode '{mode}'. "
+                f"Valid modes are: {', '.join(devops.deploy.MODES)}"
+            )
+    devops.deploy.configure_for_deployment(app)
+    return app
 
 
 def main():

--- a/scripts/background-pull.sh
+++ b/scripts/background-pull.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Pull changes for another branch without affecting unstaged changes
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <branch-name>"
+    exit 1
+fi
+
+BRANCH="$1"
+
+if ! git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "Branch '$BRANCH' does not exist."
+    exit 2
+fi
+
+git stash
+git checkout "$BRANCH" && git pull
+git checkout deployment-refactor
+git stash pop

--- a/wsgi.py
+++ b/wsgi.py
@@ -14,20 +14,12 @@ The deployment mode is determined by the DEPLOY environment variable.
 
 from main import create_app
 
-
-def configure_for_deployment(app):
-    """Configure the Flask app for deployment."""
-    # Health check route for deployments
-    # Many services expect a 200 response from the root URL to verify the
-    # service is running
-    @app.route('/')
-    def health_check():
-        return {'status': 'healthy', 'service': 'campus-apps'}, 200
+from campus.common.devops import deploy
 
 
 # WSGI application instance for production deployment
 app = create_app()
-configure_for_deployment(app)
+deploy.configure_for_deployment(app)
 
 
 if __name__ == "__main__":

--- a/wsgi.py
+++ b/wsgi.py
@@ -12,17 +12,16 @@ Usage with Gunicorn:
 The deployment mode is determined by the DEPLOY environment variable.
 """
 
-from main import create_app
-
+import main
 from campus.common.devops import deploy
 
 
 # WSGI application instance for production deployment
-app = create_app()
+app = main.create_app()
 deploy.configure_for_deployment(app)
 
 
 if __name__ == "__main__":
     # Fallback for direct execution (though main.py is preferred for development)
-    print("⚠️  Running WSGI module directly. For development, use: python main.py")
+    print("⚠️ Running WSGI module directly. For development, use: python main.py")
     app.run(host="0.0.0.0", port=5000, debug=False)


### PR DESCRIPTION
Streamline app creation through a single devops.deploy.create_app() factory.

Modules that can be instantiated into apps will implement an init_app() function only, to allow centralisation of error handling and configuration.