### PR TITLE
bugfix: use campus.client instead of campus.vault for YAPPERDB_URI extraction

### DIFF
--- a/campus/config.py
+++ b/campus/config.py
@@ -15,13 +15,13 @@ BASE_URLS = {
     "campus.vault": {
         devops.PRODUCTION: "https://vault.campus.nyjc.app/api/v1/",
         devops.STAGING: "https://vault.campus.nyjc.dev/api/v1/",
-        devops.TESTING: "vault.campus.testing/",
+        devops.TESTING: "https://vault.campus.testing/",
         devops.DEVELOPMENT: "https://campusvault-development.up.railway.app/api/v1/",
     },
     "campus.apps": {
         devops.PRODUCTION: "https://api.campus.nyjc.app/api/v1/",
         devops.STAGING: "https://api.campus.nyjc.dev/api/v1/",
-        devops.TESTING: "apps.campus.testing/",
+        devops.TESTING: "https://apps.campus.testing/",
         devops.DEVELOPMENT: "https://campusapps-development.up.railway.app/api/v1/",
     }
 }

--- a/campus/yapper/__init__.py
+++ b/campus/yapper/__init__.py
@@ -8,12 +8,7 @@ This package provides the Yapper class for sending and receiving events.
 # See https://docs.python.org/3/tutorial/modules.html#packages for more
 # information.
 
-import os
-
 from .base import Event, EventHandler, YapperInterface
-from .backends.sqlite import SQLiteYapper
-from .backends.postgres import PostgreSQLYapper
-from campus.vault import get_vault
 
 
 def create(**kwargs) -> YapperInterface:
@@ -42,8 +37,12 @@ def create(**kwargs) -> YapperInterface:
                    or if YAPPERDB_URI is not set for PostgreSQL environments
     """
     # Lazy-import locally to avoid polluting global namespace
+    import os
+
     from campus.client.vault.vault import VaultClient
 
+    from .backends.sqlite import SQLiteYapper
+    from .backends.postgres import PostgreSQLYapper
 
     client_id = os.getenv("CLIENT_ID")
     client_secret = os.getenv("CLIENT_SECRET")

--- a/campus/yapper/__init__.py
+++ b/campus/yapper/__init__.py
@@ -41,6 +41,10 @@ def create(**kwargs) -> YapperInterface:
         ValueError: If CLIENT_ID or CLIENT_SECRET environment variables are not set,
                    or if YAPPERDB_URI is not set for PostgreSQL environments
     """
+    # Lazy-import locally to avoid polluting global namespace
+    from campus.client.vault.vault import VaultClient
+
+
     client_id = os.getenv("CLIENT_ID")
     client_secret = os.getenv("CLIENT_SECRET")
     env = os.getenv("ENV", "development").lower()
@@ -59,8 +63,8 @@ def create(**kwargs) -> YapperInterface:
         # For now, use the development branch of the yapper db for testing
         # YAPPERDB_URI must be appropriately configured for each environment using yapper.
         case  "development" | "testing" | "staging" | "production":
-            vault = get_vault("yapper")
-            yapperdb_uri = vault.get("YAPPERDB_URI")
+            vault = VaultClient()
+            yapperdb_uri = vault["yapper"]["YAPPERDB_URI"].get()
             if not yapperdb_uri:
                 raise ValueError(
                     f"YAPPERDB_URI environment variable is required for {env} environment. "


### PR DESCRIPTION
This PR pushes an urgent bugfix causing a deployment failure in `staging`.

The use of campus.client (access via API) instead of campus.vault (direct DB access) obviates the need for VAULTDB_URI in deployments besides campus.vault, and is also more secure.