### PR TITLE
Refactor admin module and API

### DIFF
--- a/campus/apps/api/routes/admin.py
+++ b/campus/apps/api/routes/admin.py
@@ -10,6 +10,10 @@ from campus.common import devops
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
+# This file uses local imports to avoid exposing sensitive imports
+# and polluting global space
+# pylint: disable=import-outside-toplevel
+
 @bp.route("/status", methods=["GET"])
 def status():
     """Return admin status info."""
@@ -22,10 +26,8 @@ def status():
 def init_db():
     """Initialise the tables needed by api."""
     from campus import models, vault
-    models.circle.init_db()
-    models.emailotp.init_db()
-    models.user.init_db()
-    vault.client.init_db()
+    models.init_db()
+    vault.init_db()
     return {"status": "ok", "message": "Database initialised."}
 
 # Purge DB endpoint
@@ -36,7 +38,7 @@ def init_db():
 @devops.confirm_action_in_env(devops.STAGING)
 def purge_db():
     """Purge the database."""
-    from campus.storage import purge_all  # type: ignore[import-untyped]
+    from campus.storage import purge_all
     purge_all()
     return {"status": "ok", "message": f"{devops.ENV}: Database purged."}
 

--- a/campus/apps/api/routes/admin.py
+++ b/campus/apps/api/routes/admin.py
@@ -22,7 +22,6 @@ def status():
 
 @bp.route("/init-db", methods=["POST"])
 @devops.block_env(devops.PRODUCTION)
-@devops.confirm_action_in_env(devops.STAGING)
 def init_db():
     """Initialise the tables needed by api."""
     from campus import models, vault
@@ -35,7 +34,6 @@ def init_db():
 
 @bp.route("/purge-db", methods=["POST"])
 @devops.block_env(devops.PRODUCTION)
-@devops.confirm_action_in_env(devops.STAGING)
 def purge_db():
     """Purge the database."""
     from campus.storage import purge_all

--- a/campus/apps/campusauth/__init__.py
+++ b/campus/apps/campusauth/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
 
 def init_app(app: Flask | Blueprint) -> None:
     """Initialise the campusauth blueprint with the given Flask app."""
+    # pylint: disable=import-outside-toplevel
     from . import routes
     routes.init_app(app)
 

--- a/campus/apps/campusauth/__init__.py
+++ b/campus/apps/campusauth/__init__.py
@@ -12,17 +12,11 @@ from .authentication import (
     client_auth_required
 )
 
-__all__ = [
-    'init_app',
-    'init_db',
-    'authenticate_client',
-    'client_auth_required',
-]
 
+# pylint: disable=import-outside-toplevel
 
 def init_app(app: Flask | Blueprint) -> None:
     """Initialise the campusauth blueprint with the given Flask app."""
-    # pylint: disable=import-outside-toplevel
     from . import routes
     routes.init_app(app)
 
@@ -35,3 +29,11 @@ def init_db() -> None:
     models.
     """
     # campusauth relies on existing models and does not use any drums.
+
+
+__all__ = [
+    'init_app',
+    'init_db',
+    'authenticate_client',
+    'client_auth_required',
+]

--- a/campus/models/__init__.py
+++ b/campus/models/__init__.py
@@ -95,11 +95,28 @@ resources.
   invalid.
 """
 
+from campus.common import devops
+
 from . import (
     circle,
     emailotp,
     user
 )
+
+
+@devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
+def init_db():
+    """Initialize tables needed by models.
+
+    This function is intended to be called only in a test environment (using a
+    local-only db like SQLite), or in a staging environment before upgrading to
+    production.
+    """
+    circle.init_db()
+    emailotp.init_db()
+    user.init_db()
+
 
 __all__ = [
     "circle",

--- a/campus/vault/__init__.py
+++ b/campus/vault/__init__.py
@@ -189,11 +189,12 @@ def init_app(app: Flask | Blueprint) -> None:
 
 
 @devops.block_env(devops.PRODUCTION)
+@devops.confirm_action_in_env(devops.STAGING)
 def init_db():
     """Initialize the tables needed by the model.
 
-    This function is intended to be called only in a test environment or
-    staging.
+    This function is intended to be called only in a test or
+    staging environment.
     """
     # Initialize vault table
     with db.get_connection_context() as conn:


### PR DESCRIPTION
This PR makes minor refactors for the admin module:

- Create `campus.models.init_db()` convenience function that initialises all model databases
- Move devops confirmation out from routes to init_db() function
- linting improvements
- cleaner namespace through use of local imports