### PR TITLE
Outline test strategies

### DIFF
--- a/campus/apps/__init__.py
+++ b/campus/apps/__init__.py
@@ -25,7 +25,7 @@ def init_app(app: Blueprint | Flask) -> None:
     if isinstance(app, Flask):
         from campus.client.vault import get_vault
         vault = get_vault()
-    app.secret_key = vault["campus"]["SECRET_KEY"].get()["value"]
+        app.secret_key = vault["campus"]["SECRET_KEY"].get()["value"]
 
 
 __all__ = [

--- a/campus/apps/__init__.py
+++ b/campus/apps/__init__.py
@@ -16,7 +16,18 @@ from . import api, campusauth, oauth
 
 
 def init_app(app: Blueprint | Flask) -> None:
-    """Initialize the Campus app with all modules."""
+    """Initialize the Campus app with all modules.
+
+    This function sets up all Campus apps components including API,
+    authentication, and OAuth modules.
+
+    Note: For creating new Flask applications, use the recommended pattern:
+        from campus.common.devops.deploy import create_app
+        import campus.apps
+        app = create_app(campus.apps)
+
+    This ensures proper error handling and deployment configuration.
+    """
     api.init_app(app)
     campusauth.init_app(app)
     oauth.init_app(app)

--- a/campus/vault/__init__.py
+++ b/campus/vault/__init__.py
@@ -80,7 +80,6 @@ from .vault import get_vault
 
 __all__ = [
     "get_vault",
-    "create_app",
     "init_app",
     "init_db",
     "access",
@@ -91,19 +90,19 @@ __all__ = [
 # This file uses local imports to avoid polluting global space
 # pylint: disable=import-outside-toplevel
 
-def create_app() -> Flask:
-    """Factory function to create the vault app.
-
-    This is called if vault is run as a standalone app.
-    """
-    app = Flask(__name__)
-    init_app(app)
-    errors.init_app(app)
-    return app
-
 
 def init_app(app: Flask | Blueprint) -> None:
-    """Initialize the vault blueprints with the given Flask app."""
+    """Initialize the vault blueprints with the given Flask app.
+
+    This function sets up the vault service routes and blueprints.
+
+    Note: For creating new Flask applications, use the recommended pattern:
+        from campus.common.devops.deploy import create_app
+        import campus.vault
+        app = create_app(campus.vault)
+
+    This ensures proper error handling and deployment configuration.
+    """
     bp = Blueprint('vault_v1', __name__, url_prefix='/api/v1')
     from . import routes
     routes.vaults.init_app(bp)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -180,6 +180,13 @@ campus/
 
 ## 🧪 Testing Your Changes
 
+Campus provides **three testing strategies** for different scenarios. See **[Testing Strategies](testing-strategies.md)** for comprehensive documentation.
+
+**Quick Summary**:
+- **Unit tests**: `poetry run python tests/run_tests.py unit` (Flask test clients)
+- **Integration tests**: `poetry run python tests/run_tests.py integration` (local services)  
+- **Manual testing**: Set `ENV=development` (Railway services)
+
 ### Individual Package Testing
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 ## Development
 
 - **[Development Guidelines](development-guidelines.md)** — Architectural patterns, design decisions, and best practices
+- **[Testing Strategies](testing-strategies.md)** — Three testing approaches: development server, local services, and Flask test clients
 
 ## API and Endpoints
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -201,6 +201,16 @@ poetry install --all-extras
 
 ## Testing and CI/CD
 
+### Testing Strategies
+
+Campus provides **three distinct testing strategies** for different use cases:
+
+1. **Development Server Testing** - Test against live Railway services with simulated data
+2. **Local Service Testing** - Run services locally in background for integration testing  
+3. **Flask Test Client Testing** - In-process testing with no network calls (fastest)
+
+**📖 See [Testing Strategies](testing-strategies.md) for comprehensive documentation and examples.**
+
 ### Test Organization and Structure
 
 **Test Separation**: Tests are organized by package and type for maintainability and reliability.

--- a/docs/testing-strategies.md
+++ b/docs/testing-strategies.md
@@ -1,0 +1,243 @@
+# Campus Testing Strategies
+
+This document outlines the three primary testing strategies available in the Campus project. Each strategy serves different purposes and provides different levels of integration with real services.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Strategy 1: Development Server Testing](#strategy-1-development-server-testing)
+- [Strategy 2: Local Service Testing](#strategy-2-local-service-testing)
+- [Strategy 3: Flask Test Client Testing](#strategy-3-flask-test-client-testing)
+- [When to Use Each Strategy](#when-to-use-each-strategy)
+- [Quick Reference](#quick-reference)
+
+## Overview
+
+Campus provides three distinct testing strategies to accommodate different testing needs:
+
+| Strategy | Environment | Data | Network | Use Case |
+|----------|-------------|------|---------|----------|
+| **Development Server** | Remote (Railway) | Simulated real data | Real HTTP | Manual testing, demos |
+| **Local Services** | Local background processes | Test data | Real HTTP | Integration testing |
+| **Flask Test Client** | In-process Flask apps | Test data | No network | Unit/component testing |
+
+All strategies use the same Campus client interface, ensuring consistent testing patterns across different levels of integration.
+
+## Strategy 1: Development Server Testing
+
+**Purpose**: Test against live development services with simulated real data.
+
+### Environment
+- **Vault**: `https://campusvault-development.up.railway.app/api/v1/`
+- **Apps**: `https://campusapps-development.up.railway.app/api/v1/`
+- **Data**: Simulated realistic data (different from production)
+- **Network**: Real HTTP requests over the internet
+
+### Usage
+
+```python
+import os
+from campus.client import Campus
+
+# Set environment to development
+os.environ['ENV'] = 'development'
+
+# Client automatically uses development servers
+client = Campus()
+
+# Use normally - all requests go to Railway development services
+vault = client.vault["my-vault"]
+vault.set("api_key", "test-value")
+```
+
+### When to Use
+- ✅ Manual testing and verification
+- ✅ Demos and showcases  
+- ✅ Testing with realistic data patterns
+- ✅ Verifying deployment configurations
+- ❌ Automated CI/CD (requires internet)
+- ❌ Unit tests (too slow, external dependencies)
+
+## Strategy 2: Local Service Testing
+
+**Purpose**: Run Campus services locally in background threads for integration testing.
+
+### Environment
+- **Services**: Local Flask applications running in background
+- **Data**: Test databases (PostgreSQL, MongoDB)
+- **Network**: Real HTTP requests to localhost
+- **Cleanup**: Automatic service shutdown
+
+### Setup
+
+```python
+from tests.fixtures import services
+
+# Context manager automatically handles setup/cleanup
+with services.init() as manager:
+    # manager.vault_app and manager.apps_app are running
+    
+    # Create clients normally - they connect to local services
+    client = Campus()
+    
+    # Test against local services
+    vault = client.vault["test-vault"]
+    vault.set("test_key", "test_value")
+    
+    # Services automatically cleaned up when context exits
+```
+
+### Service Management
+
+The `ServiceManager` follows strict initialization order:
+1. **Vault** → Creates test credentials
+2. **Yapper** → Requires vault credentials
+3. **Apps** → Requires vault + yapper
+
+```python
+# Manual service management (if needed)
+manager = services.create_service_manager()
+manager.setup()  # Start all services
+# ... test code ...
+manager.close()  # Clean shutdown
+```
+
+### When to Use
+- ✅ Integration testing
+- ✅ Testing service interactions
+- ✅ End-to-end workflows
+- ✅ CI/CD automated testing
+- ❌ Unit tests (too heavy)
+- ❌ Performance testing (overhead from background services)
+
+## Strategy 3: Flask Test Client Testing
+
+NOTE: Not fully working yet, WIP
+
+**Purpose**: Test Campus clients with in-process Flask applications (no network calls).
+
+### Environment
+- **Services**: Flask app instances (not running servers)
+- **Data**: Test data in-memory or test databases
+- **Network**: No network - direct Flask test client calls
+- **Speed**: Fastest option
+
+### Usage
+
+```python
+from tests import flask_test
+from tests.fixtures import services
+
+# Create Campus client with Flask test adapters
+with services.init() as manager:
+    client = flask_test.create_test_client_from_manager(manager)
+    
+    # All operations use Flask test client internally
+    vault = client.vault["test-vault"]  
+    vault.set("key", "value")  # No HTTP - direct Flask calls
+```
+
+### Direct Flask App Testing
+
+```python
+from tests.flask_test import FlaskTestClient
+from campus.common.devops import deploy
+import campus.vault
+
+# Create Flask app manually
+vault_app = deploy.create_app(campus.vault)
+
+# Wrap with our adapter
+test_client = FlaskTestClient(vault_app)
+
+# Use as JsonClient
+response = test_client.get('/api/v1/vault/')
+print(response.status_code)  # 401 (authentication required)
+print(response.json())       # Error details
+```
+
+### When to Use
+- ✅ Unit testing of client logic
+- ✅ Component testing
+- ✅ Fast test feedback loops
+- ✅ Testing error handling
+- ✅ CI/CD (fastest option)
+- ❌ Testing actual network behavior
+- ❌ Testing service deployment configurations
+
+## When to Use Each Strategy
+
+### Development Workflow
+
+| Phase | Strategy | Rationale |
+|-------|----------|-----------|
+| **Unit Testing** | Flask Test Client | Fastest feedback, no external dependencies |
+| **Integration Testing** | Local Services | Test service interactions, realistic but controlled |
+| **Manual Testing** | Development Server | Test with realistic data and deployment config |
+| **Demo/Showcase** | Development Server | Most realistic user experience |
+
+### Error Debugging
+
+1. **Start with Flask Test Client** - Fast iteration, direct debugging
+2. **Move to Local Services** - If you need service interactions
+3. **Use Development Server** - If you suspect deployment/network issues
+
+## Quick Reference
+
+### Import Patterns
+
+```python
+# Development Server
+from campus.client import Campus
+client = Campus()  # Uses ENV variable
+
+# Local Services  
+from tests.fixtures import services
+with services.init() as manager:
+    client = Campus()  # Connects to local services
+
+# Flask Test Client
+from tests.flask_test import create_test_client_from_manager
+from tests.fixtures import services
+with services.init() as manager:
+    client = create_test_client_from_manager(manager)
+```
+
+### Configuration
+
+```python
+# Set testing environment
+import os
+os.environ['ENV'] = 'testing'    # Local services
+os.environ['ENV'] = 'development'  # Remote development server
+
+# Test configuration for Flask apps
+from tests.flask_test import configure_for_testing
+configure_for_testing(app)  # Sets DEBUG=True, TESTING=True, adds health routes
+```
+
+### Service Dependencies
+
+**Critical**: Services must be initialized in dependency order:
+
+```
+vault → yapper → apps
+```
+
+- **Vault**: No dependencies, provides authentication
+- **Yapper**: Requires vault credentials for database access  
+- **Apps**: Imports yapper routes, needs yapper fully initialized
+
+**Note**: Current limitation - Apps service may fail during testing due to yapper → vault connection requirements during import. This is expected behavior and indicates architectural improvements needed in the yapper module for lazy loading.
+
+### Best Practices
+
+1. **Use context managers** for automatic cleanup
+2. **Start with Flask test client** for new features
+3. **Test error paths** with all strategies
+4. **Keep tests independent** - don't rely on test order
+5. **Use appropriate strategy** for the testing goal
+
+---
+
+*For more information about testing, see [CONTRIBUTING.md](CONTRIBUTING.md) and [development-guidelines.md](development-guidelines.md).*

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -1,0 +1,157 @@
+"""tests.fixtures.services
+
+Service management for local Campus service instances.
+Provides a clean interface to start and stop all Campus services for testing.
+"""
+
+from contextlib import contextmanager
+from typing import Optional
+
+from . import setup, vault, apps, storage, yapper
+
+
+class ServiceManager:
+    """Manages local Campus service instances for testing.
+
+    This class coordinates the setup of all required services:
+    - Database setup (PostgreSQL, MongoDB)
+    - Service initialization (vault, apps, yapper, storage)
+    - Flask app creation for test clients
+
+    Usage:
+        manager = ServiceManager()
+        manager.setup()
+        # Use manager.vault_app and manager.apps_app
+        manager.close()
+
+    Or use as context manager:
+        with services.init() as manager:
+            # Use manager.vault_app and manager.apps_app
+    """
+
+    def __init__(self):
+        self.vault_app: Optional[object] = None
+        self.apps_app: Optional[object] = None
+        self._setup_done = False
+
+    def setup(self):
+        """Set up all Campus services for testing.
+
+        This method:
+        1. Sets up test environment variables
+        2. Configures database connections (PostgreSQL, MongoDB)
+        3. Initializes all Campus services (vault, apps, yapper, storage)
+        4. Creates Flask applications ready for testing
+
+        Returns:
+            ServiceManager: Self for method chaining
+        """
+        if self._setup_done:
+            return self
+
+        # Set up test environment
+        setup.set_test_env_vars()
+        setup.set_postgres_env_vars()
+        setup.set_mongodb_env_vars()
+
+        # Initialize services in dependency order: vault → yapper → apps
+        # This order is crucial because:
+        # 1. Vault must be initialized first to create client credentials
+        # 2. Yapper needs vault credentials to access secrets
+        # 3. Apps imports yapper routes, so yapper must be ready first
+
+        # Step 1: Initialize vault service and create Flask app
+        vault.init()      # Creates test client credentials
+        import campus.vault
+        self.vault_app = campus.vault.create_app()
+
+        # Step 2: Initialize storage (doesn't depend on other services)
+        storage.init()    # Sets up database connections
+
+        # Step 3: Initialize yapper service
+        # This must happen after vault is initialized because yapper
+        # needs vault credentials to access secret database URIs
+        yapper.init()     # Requires vault credentials
+
+        # Step 4: Initialize apps service last
+        # Apps imports yapper routes, so yapper must be fully initialized first
+        apps.init()       # Requires vault credentials
+
+        # Step 5: Create apps Flask application
+        # Import here to avoid circular imports and ensure all dependencies are ready
+        try:
+            import campus.apps
+            from campus.common import devops
+            self.apps_app = devops.deploy.create_app(campus.apps)
+        except Exception as e:
+            # If we can't create the apps service due to dependencies,
+            # create a minimal Flask app instead
+            from flask import Flask
+            self.apps_app = Flask('test_apps_minimal')
+            self.apps_app.config['TESTING'] = True
+
+            @self.apps_app.route('/')
+            def health():
+                return {'status': 'healthy', 'service': 'test-apps-minimal'}
+
+            print(
+                f"Warning: Could not create full apps service, using minimal app: {e}")
+
+        self._setup_done = True
+        return self
+
+    def close(self):
+        """Clean up service instances.
+
+        This method cleans up resources and resets the manager state.
+        Can be called multiple times safely.
+        """
+        # Clean up Flask apps
+        if self.vault_app is not None:
+            # Flask apps don't need explicit cleanup, but we can clear references
+            self.vault_app = None
+
+        if self.apps_app is not None:
+            self.apps_app = None
+
+        self._setup_done = False
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self.setup()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+
+
+@contextmanager
+def init():
+    """Context manager for Campus service setup.
+
+    This is the main entrypoint for setting up local Campus services.
+    It ensures proper cleanup even if exceptions occur.
+
+    Usage:
+        with services.init() as manager:
+            # manager.vault_app and manager.apps_app are ready
+            vault_client = FlaskTestClient(manager.vault_app)
+            apps_client = FlaskTestClient(manager.apps_app)
+
+    Yields:
+        ServiceManager: Configured service manager with running applications
+    """
+    manager = ServiceManager()
+    try:
+        yield manager.setup()
+    finally:
+        manager.close()
+
+
+def create_service_manager():
+    """Factory function to create a new ServiceManager.
+
+    Returns:
+        ServiceManager: New uninitialized service manager
+    """
+    return ServiceManager()

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -60,10 +60,14 @@ class ServiceManager:
         # 2. Yapper needs vault credentials to access secrets
         # 3. Apps imports yapper routes, so yapper must be ready first
 
-        # Step 1: Initialize vault service and create Flask app
+        # Step 1: Initialize vault service and create Flask app using devops.deploy
         vault.init()      # Creates test client credentials
         import campus.vault
-        self.vault_app = campus.vault.create_app()
+        from campus.common import devops
+        from tests import flask_test
+
+        self.vault_app = devops.deploy.create_app(campus.vault)
+        flask_test.configure_for_testing(self.vault_app)
 
         # Step 2: Initialize storage (doesn't depend on other services)
         storage.init()    # Sets up database connections
@@ -77,25 +81,11 @@ class ServiceManager:
         # Apps imports yapper routes, so yapper must be fully initialized first
         apps.init()       # Requires vault credentials
 
-        # Step 5: Create apps Flask application
+        # Step 5: Create apps Flask application using devops.deploy
         # Import here to avoid circular imports and ensure all dependencies are ready
-        try:
-            import campus.apps
-            from campus.common import devops
-            self.apps_app = devops.deploy.create_app(campus.apps)
-        except Exception as e:
-            # If we can't create the apps service due to dependencies,
-            # create a minimal Flask app instead
-            from flask import Flask
-            self.apps_app = Flask('test_apps_minimal')
-            self.apps_app.config['TESTING'] = True
-
-            @self.apps_app.route('/')
-            def health():
-                return {'status': 'healthy', 'service': 'test-apps-minimal'}
-
-            print(
-                f"Warning: Could not create full apps service, using minimal app: {e}")
+        import campus.apps
+        self.apps_app = devops.deploy.create_app(campus.apps)
+        flask_test.configure_for_testing(self.apps_app)
 
         self._setup_done = True
         return self

--- a/tests/flask_test/__init__.py
+++ b/tests/flask_test/__init__.py
@@ -1,0 +1,26 @@
+"""tests.flask_test
+
+Flask test client adapters for Campus testing.
+
+This module provides adapter classes that wrap Flask's test client to implement
+the Campus JsonClient and JsonResponse protocols. This enables using Flask test
+clients with the Campus client interface for testing without actual HTTP calls.
+
+Key Components:
+- FlaskTestResponse: Adapts werkzeug.test.TestResponse to JsonResponse protocol
+- FlaskTestClient: Adapts Flask test client to JsonClient protocol  
+- create_test_client: Factory function for creating Campus client with Flask apps
+"""
+
+from .client import FlaskTestClient
+from .response import FlaskTestResponse
+from .factory import create_test_client, create_test_client_from_manager
+from .configure import configure_for_testing
+
+__all__ = [
+    "FlaskTestClient",
+    "FlaskTestResponse",
+    "create_test_client",
+    "create_test_client_from_manager",
+    "configure_for_testing"
+]

--- a/tests/flask_test/__init__.py
+++ b/tests/flask_test/__init__.py
@@ -17,6 +17,7 @@ from .response import FlaskTestResponse
 from .factory import create_test_client, create_test_client_from_manager
 from .configure import configure_for_testing
 
+
 __all__ = [
     "FlaskTestClient",
     "FlaskTestResponse",

--- a/tests/flask_test/client.py
+++ b/tests/flask_test/client.py
@@ -1,0 +1,126 @@
+"""tests.flask_test.client
+
+FlaskTestClient adapter for Campus JsonClient protocol.
+"""
+
+from typing import Any, Iterable, Mapping, Self
+from urllib.parse import urljoin
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+from campus.common.http.interface import JsonDict, JsonResponse
+from .response import FlaskTestResponse
+
+
+class FlaskTestClient:
+    """Adapter that wraps Flask test client to implement JsonClient protocol.
+
+    This class adapts Flask's test client to match the Campus JsonClient interface,
+    enabling seamless testing with Flask apps without actual HTTP requests.
+    """
+
+    def __init__(
+            self,
+            app: Flask,
+            base_url: str | None = None,
+            *,
+            auth: Iterable[str] | str | None = None,
+            headers: Mapping[str, str] | None = None,
+            **kwargs: Any
+    ):
+        """Initialize with a Flask app for testing.
+
+        Args:
+            app: The Flask application to test
+            base_url: Base URL for the client (for compatibility)
+            auth: Authentication (ignored for Flask test client)
+            headers: Default headers (ignored for Flask test client)
+            **kwargs: Additional arguments (ignored)
+        """
+        self.app = app
+        self.base_url = base_url
+        self._test_client = app.test_client()
+
+        # Store app context for proper request handling
+        self._app_context = None
+
+    def _ensure_app_context(self):
+        """Ensure we have an active app context."""
+        if self._app_context is None:
+            self._app_context = self.app.app_context()
+            self._app_context.push()
+
+    def _make_path(self, path: str) -> str:
+        """Convert path to full URL if base_url is set, otherwise return path."""
+        if self.base_url:
+            return urljoin(self.base_url, path.lstrip('/'))
+        return path
+
+    def get(self: Self, path: str, params: JsonDict | None = None) -> JsonResponse:
+        """Sends a GET request."""
+        self._ensure_app_context()
+
+        response = self._test_client.get(
+            self._make_path(path),
+            query_string=params
+        )
+        return FlaskTestResponse(response)
+
+    def post(self: Self, path: str, json: JsonDict | None = None) -> JsonResponse:
+        """Sends a POST request."""
+        self._ensure_app_context()
+
+        response = self._test_client.post(
+            self._make_path(path),
+            json=json,
+            content_type='application/json'
+        )
+        return FlaskTestResponse(response)
+
+    def put(self: Self, path: str, json: JsonDict | None = None) -> JsonResponse:
+        """Sends a PUT request."""
+        self._ensure_app_context()
+
+        response = self._test_client.put(
+            self._make_path(path),
+            json=json,
+            content_type='application/json'
+        )
+        return FlaskTestResponse(response)
+
+    def delete(self: Self, path: str, json: JsonDict | None = None) -> JsonResponse:
+        """Sends a DELETE request."""
+        self._ensure_app_context()
+
+        response = self._test_client.delete(
+            self._make_path(path),
+            json=json,
+            content_type='application/json'
+        )
+        return FlaskTestResponse(response)
+
+    def patch(self: Self, path: str, json: Any = None) -> JsonResponse:
+        """Sends a PATCH request."""
+        self._ensure_app_context()
+
+        response = self._test_client.patch(
+            self._make_path(path),
+            json=json,
+            content_type='application/json'
+        )
+        return FlaskTestResponse(response)
+
+    def close(self):
+        """Clean up app context."""
+        if self._app_context is not None:
+            self._app_context.pop()
+            self._app_context = None
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()

--- a/tests/flask_test/client.py
+++ b/tests/flask_test/client.py
@@ -7,9 +7,9 @@ from typing import Any, Iterable, Mapping, Self
 from urllib.parse import urljoin
 
 from flask import Flask
-from flask.testing import FlaskClient
 
 from campus.common.http.interface import JsonDict, JsonResponse
+
 from .response import FlaskTestResponse
 
 

--- a/tests/flask_test/configure.py
+++ b/tests/flask_test/configure.py
@@ -1,0 +1,41 @@
+"""tests.flask_test.configure
+
+Configuration utilities for Flask apps in testing environments.
+"""
+
+from flask import Flask
+from campus.common import devops
+
+
+def configure_for_testing(app: Flask) -> None:
+    """Configure the Flask app for testing.
+
+    This function sets up Flask applications with testing-specific configuration:
+    - Enables debug mode for better error messages
+    - Sets testing flag to True
+    - Adds a simple health check route
+    - Configures proper error handling for tests
+
+    Args:
+        app: Flask application to configure
+    """
+    # Enable testing mode
+    app.config['TESTING'] = True
+    app.config['DEBUG'] = True
+
+    # Disable CSRF for easier testing
+    app.config['WTF_CSRF_ENABLED'] = False
+
+    # Add a simple health check route for testing
+    @app.route('/test/health')
+    def test_health_check():
+        return {
+            'status': 'healthy',
+            'environment': devops.ENV,
+            'testing': True,
+            'service': app.name
+        }, 200
+
+    # Initialize error handling (but don't override deployment-specific routes)
+    import campus.common.errors
+    campus.common.errors.init_app(app)

--- a/tests/flask_test/factory.py
+++ b/tests/flask_test/factory.py
@@ -1,0 +1,79 @@
+"""tests.flask_test.factory
+
+Factory functions for creating Campus test client with Flask apps.
+"""
+
+from typing import Mapping, cast
+
+from campus.client.core import Campus
+from campus.common.http.interface import JsonClient
+from .client import FlaskTestClient
+
+
+def create_test_client_from_manager(manager) -> Campus:
+    """Create a Campus client from a ServiceManager.
+
+    This is the preferred way to create test clients as it ensures proper
+    service setup and resource management.
+
+    Args:
+        manager: ServiceManager instance with vault_app and apps_app set up
+
+    Returns:
+        Campus: Client instance configured with Flask test clients
+
+    Example:
+        from tests.flask_test import create_test_client_from_manager
+        from tests.fixtures import services
+
+        with services.init() as manager:
+            client = create_test_client_from_manager(manager)
+            result = client.vault["test"]["key"].get()
+    """
+    if not manager.vault_app or not manager.apps_app:
+        raise ValueError(
+            "ServiceManager must be set up with vault_app and apps_app")
+
+    # Create override mapping with Flask test clients, cast to satisfy typing
+    override: Mapping[str, JsonClient] = {
+        "campus.vault": cast(JsonClient, FlaskTestClient(
+            manager.vault_app,
+            base_url="http://localhost:8080/api/v1/"
+        )),
+        "campus.apps": cast(JsonClient, FlaskTestClient(
+            manager.apps_app,
+            base_url="http://localhost:8081/api/v1/"
+        )),
+    }
+
+    return Campus(override=override)
+
+
+def create_test_client() -> Campus:
+    """Factory function to create a Campus client using Flask test clients.
+
+    This creates a Campus client that uses FlaskTestClient instances instead
+    of making actual HTTP requests. Perfect for integration testing.
+
+    Note: This function sets up services automatically but doesn't provide
+    a way to clean them up. For better resource management, use:
+
+    Example:
+        from tests.flask_test import create_test_client_from_manager
+        from tests.fixtures import services
+
+        with services.init() as manager:
+            client = create_test_client_from_manager(manager)
+            # Services are automatically cleaned up
+
+    Returns:
+        Campus: Client instance configured with Flask test clients
+    """
+    from tests.fixtures import services
+
+    # This creates a service manager but doesn't clean it up
+    # Use create_test_client_from_manager() with services.init() for better control
+    manager = services.create_service_manager()
+    manager.setup()
+
+    return create_test_client_from_manager(manager)

--- a/tests/flask_test/response.py
+++ b/tests/flask_test/response.py
@@ -6,8 +6,6 @@ FlaskTestResponse adapter for Campus JsonResponse protocol.
 from typing import Any
 from werkzeug.test import TestResponse
 
-from campus.common.http.interface import JsonResponse
-
 
 class FlaskTestResponse:
     """Adapter that wraps werkzeug.test.TestResponse to implement JsonResponse protocol.

--- a/tests/flask_test/response.py
+++ b/tests/flask_test/response.py
@@ -1,0 +1,103 @@
+"""tests.flask_test.response
+
+FlaskTestResponse adapter for Campus JsonResponse protocol.
+"""
+
+from typing import Any
+from werkzeug.test import TestResponse
+
+from campus.common.http.interface import JsonResponse
+
+
+class FlaskTestResponse:
+    """Adapter that wraps werkzeug.test.TestResponse to implement JsonResponse protocol.
+
+    This class adapts Flask's test response to match the Campus JsonResponse interface,
+    enabling seamless testing with Flask apps without actual HTTP requests.
+    """
+
+    def __init__(self, response: TestResponse):
+        """Initialize with a Flask test response.
+
+        Args:
+            response: The werkzeug TestResponse to wrap
+        """
+        self._response = response
+
+    @property
+    def status_code(self) -> int:
+        """HTTP status code of the response."""
+        return self._response.status_code
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Returns headers of the response as a dict.
+
+        Converts werkzeug Headers to plain dict[str, str].
+        """
+        return {k: v for k, v in self._response.headers.items()}
+
+    @property
+    def text(self) -> str:
+        """Returns the response body as a string."""
+        return self._response.get_data(as_text=True)
+
+    def ok(self) -> bool:
+        """Returns True if the response status code is 2xx, False otherwise."""
+        return 200 <= self.status_code < 300
+
+    def client_error(self) -> bool:
+        """Returns True if the response status code is 4xx, False otherwise."""
+        return 400 <= self.status_code < 500
+
+    def server_error(self) -> bool:
+        """Returns True if the response status code is 5xx, False otherwise."""
+        return 500 <= self.status_code < 600
+
+    def raise_for_status(self) -> None:
+        """Raises an exception if the response status code indicates an error.
+
+        Raises:
+            AuthenticationError: If the status code is 401
+            AccessDeniedError: If the status code is 403
+            NotFoundError: If the status code is 404
+            ConflictError: If the status code is 409
+            InvalidRequestError: If the status code is 400 or 422
+            HttpClientError: For other 4xx or 5xx status codes
+        """
+        from campus.common.http.errors import (
+            AuthenticationError,
+            AccessDeniedError,
+            NotFoundError,
+            ConflictError,
+            InvalidRequestError,
+            HttpClientError,
+        )
+
+        if not (self.client_error() or self.server_error()):
+            return
+
+        status = self.status_code
+        message = self.text
+
+        match status:
+            case 400:
+                raise InvalidRequestError(f"{status} Bad Request: {message}")
+            case 401:
+                raise AuthenticationError(f"{status} Unauthorized: {message}")
+            case 403:
+                raise AccessDeniedError(f"{status} Forbidden: {message}")
+            case 404:
+                raise NotFoundError(f"{status} Not Found: {message}")
+            case 409:
+                raise ConflictError(f"{status} Conflict: {message}")
+            case 422:
+                raise InvalidRequestError(
+                    f"{status} Unprocessable Entity: {message}")
+            case _:
+                # Generic error for other 4xx/5xx codes
+                raise HttpClientError(f"{status} HTTP Error: {message}")
+
+    def json(self) -> Any:
+        """Returns the response body as JSON."""
+        return self._response.get_json()

--- a/tests/flask_test/test_basic.py
+++ b/tests/flask_test/test_basic.py
@@ -1,0 +1,151 @@
+"""tests.flask_test.test_basic
+
+Basic tests for FlaskTestClient functionality.
+"""
+
+import unittest
+
+from flask import Flask
+
+from tests.flask_test import FlaskTestClient, FlaskTestResponse
+
+
+class TestFlaskTestResponse(unittest.TestCase):
+    """Test FlaskTestResponse adapter functionality."""
+
+    def setUp(self):
+        """Set up test Flask app."""
+        self.app = Flask(__name__)
+
+        @self.app.route('/success')
+        def success():
+            return {'message': 'success'}, 200
+
+        @self.app.route('/error')
+        def error():
+            return {'error': 'not found'}, 404
+
+        @self.app.route('/json')
+        def json_endpoint():
+            return {'data': [1, 2, 3], 'count': 3}
+
+    def test_response_properties(self):
+        """Test basic response properties."""
+        with self.app.test_client() as client:
+            response = FlaskTestResponse(client.get('/success'))
+
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(response.ok())
+            self.assertFalse(response.client_error())
+            self.assertFalse(response.server_error())
+
+    def test_json_response(self):
+        """Test JSON response parsing."""
+        with self.app.test_client() as client:
+            response = FlaskTestResponse(client.get('/json'))
+
+            json_data = response.json()
+            self.assertEqual(json_data['data'], [1, 2, 3])
+            self.assertEqual(json_data['count'], 3)
+
+    def test_headers(self):
+        """Test headers conversion."""
+        with self.app.test_client() as client:
+            response = FlaskTestResponse(client.get('/success'))
+
+            headers = response.headers
+            self.assertIsInstance(headers, dict)
+            self.assertIn('Content-Type', headers)
+
+    def test_error_status(self):
+        """Test error status detection."""
+        with self.app.test_client() as client:
+            response = FlaskTestResponse(client.get('/error'))
+
+            self.assertEqual(response.status_code, 404)
+            self.assertFalse(response.ok())
+            self.assertTrue(response.client_error())
+            self.assertFalse(response.server_error())
+
+
+class TestFlaskTestClient(unittest.TestCase):
+    """Test FlaskTestClient adapter functionality."""
+
+    def setUp(self):
+        """Set up test Flask app."""
+        self.app = Flask(__name__)
+
+        @self.app.route('/get-test')
+        def get_test():
+            return {'method': 'GET'}
+
+        @self.app.route('/post-test', methods=['POST'])
+        def post_test():
+            from flask import request
+            data = request.get_json() or {}
+            return {'method': 'POST', 'received': data}
+
+        @self.app.route('/put-test', methods=['PUT'])
+        def put_test():
+            return {'method': 'PUT'}
+
+        @self.app.route('/delete-test', methods=['DELETE'])
+        def delete_test():
+            return {'method': 'DELETE'}
+
+        @self.app.route('/patch-test', methods=['PATCH'])
+        def patch_test():
+            return {'method': 'PATCH'}
+
+    def test_get_request(self):
+        """Test GET request handling."""
+        client = FlaskTestClient(self.app)
+        response = client.get('/get-test')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['method'], 'GET')
+
+    def test_post_request(self):
+        """Test POST request with JSON."""
+        client = FlaskTestClient(self.app)
+        test_data = {'key': 'value', 'number': 42}
+        response = client.post('/post-test', json=test_data)
+
+        self.assertEqual(response.status_code, 200)
+        json_data = response.json()
+        self.assertEqual(json_data['method'], 'POST')
+        self.assertEqual(json_data['received'], test_data)
+
+    def test_put_request(self):
+        """Test PUT request handling."""
+        client = FlaskTestClient(self.app)
+        response = client.put('/put-test')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['method'], 'PUT')
+
+    def test_delete_request(self):
+        """Test DELETE request handling."""
+        client = FlaskTestClient(self.app)
+        response = client.delete('/delete-test')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['method'], 'DELETE')
+
+    def test_patch_request(self):
+        """Test PATCH request handling."""
+        client = FlaskTestClient(self.app)
+        response = client.patch('/patch-test')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['method'], 'PATCH')
+
+    def test_context_manager(self):
+        """Test context manager functionality."""
+        with FlaskTestClient(self.app) as client:
+            response = client.get('/get-test')
+            self.assertEqual(response.status_code, 200)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a `tests.flask_test` module with wrappers that allow setting up a test client that sends requests directly to the service app and does not access the network.

It also adds factory/entrypoint functions that allow each testing strategy to be invoked with a single call.

Finally, it adds documentation for each strategy: when and how to use it.