### PR TITLE
feat: add purge_database function for MongoDB and PostgreSQL; enforce testing environment in ServiceManager setup

### DIFF
--- a/tests/fixtures/mongodb.py
+++ b/tests/fixtures/mongodb.py
@@ -6,6 +6,8 @@ Functions for MongoDB database management during testing.
 import os
 from pymongo import MongoClient
 
+from campus.common import devops
+
 
 def get_mongodb_uri(database_name: str | None = None) -> str:
     """Get MongoDB connection URI for testing.
@@ -106,6 +108,7 @@ def ensure_database_exists(database_name: str) -> None:
         print(f"✅ MongoDB database '{database_name}' created successfully")
 
 
+@devops.require_env(devops.TESTING)
 def purge_database(database_name: str) -> None:
     """Purge (drop and recreate) a MongoDB database for clean testing state.
 

--- a/tests/fixtures/postgres.py
+++ b/tests/fixtures/postgres.py
@@ -6,6 +6,8 @@ Functions for PostgreSQL database management during testing.
 import os
 import subprocess
 
+from campus.common import devops
+
 
 def database_exists(database_name: str) -> bool:
     """Check if a PostgreSQL database exists.
@@ -88,6 +90,7 @@ def ensure_database_exists(database_name: str) -> None:
         print(f"✅ {database_name} database created successfully")
 
 
+@devops.require_env(devops.TESTING)
 def purge_database(database_name: str) -> None:
     """Purge (drop and recreate) a PostgreSQL database for clean testing state.
 

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from typing import Optional, cast
 
 from . import setup, vault, apps, storage, yapper
+from campus.common import devops
 
 # pylint: disable=import-outside-toplevel
 
@@ -66,6 +67,14 @@ class ServiceManager:
         Returns:
             ServiceManager: Self for method chaining
         """
+        # Ensure we're not accidentally running in development/production
+        current_env = os.environ.get("ENV")
+        if current_env in ("development", "production"):
+            raise RuntimeError(
+                f"ServiceManager.setup() cannot be run in {current_env} environment. "
+                f"This would overwrite secrets and databases. Use ENV=testing only."
+            )
+
         if self._setup_done:
             return self
 


### PR DESCRIPTION
Issue resolved: it was caused by development secrets being overwritten by test values.

To prevent similar incidents happening in future, test fixtures that set secrets in vault are protected with a `require_env()` decorator.

Fix #258 