### PR TITLE
fix: implement Option B for Flask blueprint re-registration (#337)

### DIFF
--- a/campus/auth/oauth_proxy/campus/__init__.py
+++ b/campus/auth/oauth_proxy/campus/__init__.py
@@ -18,72 +18,71 @@ from . import proxy
 
 PROVIDER = 'campus'
 
-bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
-
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialise auth routes with the given Flask app/blueprint."""
-    app.register_blueprint(bp)
+    """Initialise auth routes with the given Flask app/blueprint.
 
-
-@bp.before_request
-def before_request() -> None:
-    flask.g.proxy = proxy.get_proxy()
-
-
-@bp.get('/authorize')
-@flask_campus.unpack_request
-def authorize(
-        target: schema.Url,
-        state: schema.CampusID,  # auth session ID
-        client_id: schema.CampusID | None = None,  # Campus client ID or server
-        login_hint: schema.Email | None = None,
-) -> werkzeug.Response:
-    """Prepares the Campus OAuth authorization URL and redirects to it.
+    Creates a fresh blueprint each time to support test isolation.
     """
-    params = {"state": state}
-    if client_id:
-        params["client_id"] = client_id
-    if login_hint:
-        params["login_hint"] = login_hint
-    return flask.g.proxy.redirect_for_authorization(target, **params)
+    bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
 
+    @bp.before_request
+    def before_request() -> None:
+        flask.g.proxy = proxy.get_proxy()
 
-@bp.get('/callback')
-def callback() -> werkzeug.Response:
-    """Handles the Campus OAuth callback request.
-
-    Dispatches to success or error handlers based on payload type.
-    """
-    callback_payload = flask_campus.get_request_payload()
-    if "error" in callback_payload:
-        # TODO: For testing - display error instead of redirecting
-        # This should be replaced with proper error handling that redirects to target
-        error_html = f"""
-        <html>
-        <head><title>OAuth Error</title></head>
-        <body>
-            <h1>OAuth Error</h1>
-            <p><strong>Error:</strong> {callback_payload.get('error')}</p>
-            <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
-            <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
-            <hr>
-            <p><strong>All callback parameters:</strong></p>
-            <pre>{callback_payload}</pre>
-        </body>
-        </html>
+    @bp.get('/authorize')
+    @flask_campus.unpack_request
+    def authorize(
+            target: schema.Url,
+            state: schema.CampusID,  # auth session ID
+            client_id: schema.CampusID | None = None,  # Campus client ID or server
+            login_hint: schema.Email | None = None,
+    ) -> werkzeug.Response:
+        """Prepares the Campus OAuth authorization URL and redirects to it.
         """
-        return flask.Response(error_html, status=400, mimetype='text/html')
-    else:
-        return flask_campus.unpack_into(success_callback,
-                                        **callback_payload)
+        params = {"state": state}
+        if client_id:
+            params["client_id"] = client_id
+        if login_hint:
+            params["login_hint"] = login_hint
+        return flask.g.proxy.redirect_for_authorization(target, **params)
 
+    @bp.get('/callback')
+    def callback() -> werkzeug.Response:
+        """Handles the Campus OAuth callback request.
 
-def success_callback(**kwargs: str) -> werkzeug.Response:
-    """Campus uses Google SSO for authentication.
-    The Google OAuth callback redirects here after successful
-    authentication.
-    No data is passed from the Google auth session to here; instead
-    check for a valid Google credential.
-    """
-    return flask.g.proxy.handle_callback(**kwargs)
+        Dispatches to success or error handlers based on payload type.
+        """
+        callback_payload = flask_campus.get_request_payload()
+        if "error" in callback_payload:
+            # TODO: For testing - display error instead of redirecting
+            # This should be replaced with proper error handling that redirects to target
+            error_html = f"""
+            <html>
+            <head><title>OAuth Error</title></head>
+            <body>
+                <h1>OAuth Error</h1>
+                <p><strong>Error:</strong> {callback_payload.get('error')}</p>
+                <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
+                <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
+                <hr>
+                <p><strong>All callback parameters:</strong></p>
+                <pre>{callback_payload}</pre>
+            </body>
+            </html>
+            """
+            return flask.Response(error_html, status=400, mimetype='text/html')
+        else:
+            return flask_campus.unpack_into(success_callback,
+                                            **callback_payload)
+
+    def success_callback(**kwargs: str) -> werkzeug.Response:
+        """Campus uses Google SSO for authentication.
+        The Google OAuth callback redirects here after successful
+        authentication.
+        No data is passed from the Google auth session to here; instead
+        check for a valid Google credential.
+        """
+        return flask.g.proxy.handle_callback(**kwargs)
+
+    app.register_blueprint(bp)

--- a/campus/auth/oauth_proxy/discord/__init__.py
+++ b/campus/auth/oauth_proxy/discord/__init__.py
@@ -6,10 +6,10 @@ Reference: https://discord.com/developers/docs/topics/oauth2
 
 Discord OAuth 2.0 Client Credentials Flow:
 
-+--------+        (A)        +---------+ 
++--------+        (A)        +---------+
 |        |------------------>| Discord |
-| Campus |   Token Request    |         | 
-| Server |   (Basic Auth)    +---------+ 
+| Campus |   Token Request    |         |
+| Server |   (Basic Auth)    +---------+
 |        |        (B)        +---------+
 |        |<------------------|         |
 |        |   Access Token    | Campus  |
@@ -41,71 +41,70 @@ from . import proxy
 
 PROVIDER = "discord"
 
-bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f"/{PROVIDER}")
-
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialise Discord OAuth routes with the given Flask app/blueprint."""
-    app.register_blueprint(bp)
+    """Initialise Discord OAuth routes with the given Flask app/blueprint.
 
-
-@bp.before_request
-def before_request() -> None:
-    flask.g.proxy = proxy.get_proxy()
-
-
-@bp.get("/authorize")
-def authorize(
-        target: schema.Url,
-        prompt: Literal["consent", "none"] | None = None
-) -> werkzeug.Response:
-    """Prepares the Discord OAuth authorization URL and redirects to it."""
-    return flask.g.proxy.redirect_for_authorization(
-        target,
-        prompt=prompt
-    )
-
-
-@bp.get("/callback")
-def callback() -> werkzeug.Response:
-    """Handles the Discord OAuth callback request.
-
-    Dispatches to success or error handlers based on payload type.
+    Creates a fresh blueprint each time to support test isolation.
     """
-    callback_payload = flask_campus.get_request_payload()
-    if "error" in callback_payload:
-        # TODO: For testing - display error instead of redirecting
-        # This should be replaced with proper error handling that redirects to target
-        error_html = f"""
-        <html>
-        <head><title>OAuth Error</title></head>
-        <body>
-            <h1>OAuth Error</h1>
-            <p><strong>Error:</strong> {callback_payload.get('error')}</p>
-            <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
-            <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
-            <hr>
-            <p><strong>All callback parameters:</strong></p>
-            <pre>{callback_payload}</pre>
-        </body>
-        </html>
+    bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f"/{PROVIDER}")
+
+    @bp.before_request
+    def before_request() -> None:
+        flask.g.proxy = proxy.get_proxy()
+
+    @bp.get("/authorize")
+    def authorize(
+            target: schema.Url,
+            prompt: Literal["consent", "none"] | None = None
+    ) -> werkzeug.Response:
+        """Prepares the Discord OAuth authorization URL and redirects to it."""
+        return flask.g.proxy.redirect_for_authorization(
+            target,
+            prompt=prompt
+        )
+
+    @bp.get("/callback")
+    def callback() -> werkzeug.Response:
+        """Handles the Discord OAuth callback request.
+
+        Dispatches to success or error handlers based on payload type.
         """
-        return flask.Response(error_html, status=400, mimetype='text/html')
-    else:
-        return flask_campus.unpack_into(success_callback,
-                                        **callback_payload)
+        callback_payload = flask_campus.get_request_payload()
+        if "error" in callback_payload:
+            # TODO: For testing - display error instead of redirecting
+            # This should be replaced with proper error handling that redirects to target
+            error_html = f"""
+            <html>
+            <head><title>OAuth Error</title></head>
+            <body>
+                <h1>OAuth Error</h1>
+                <p><strong>Error:</strong> {callback_payload.get('error')}</p>
+                <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
+                <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
+                <hr>
+                <p><strong>All callback parameters:</strong></p>
+                <pre>{callback_payload}</pre>
+            </body>
+            </html>
+            """
+            return flask.Response(error_html, status=400, mimetype='text/html')
+        else:
+            return flask_campus.unpack_into(success_callback,
+                                            **callback_payload)
 
+    def success_callback(
+            state: str,
+            code: str,
+            scope: str,
+            **kwargs: str
+    ) -> werkzeug.Response:
+        """Handle a Discord OAuth callback request."""
+        return flask.g.proxy.handle_callback(
+            state,
+            code,
+            scope,
+            **kwargs
+        )
 
-def success_callback(
-        state: str,
-        code: str,
-        scope: str,
-        **kwargs: str
-) -> werkzeug.Response:
-    """Handle a Discord OAuth callback request."""
-    return flask.g.proxy.handle_callback(
-        state,
-        code,
-        scope,
-        **kwargs
-    )
+    app.register_blueprint(bp)

--- a/campus/auth/oauth_proxy/github/__init__.py
+++ b/campus/auth/oauth_proxy/github/__init__.py
@@ -16,66 +16,65 @@ from . import proxy
 
 PROVIDER = 'github'
 
-bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
-
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialise auth routes with the given Flask app/blueprint."""
+    """Initialise auth routes with the given Flask app/blueprint.
+
+    Creates a fresh blueprint each time to support test isolation.
+    """
+    bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
+
+    @bp.before_request
+    def before_request() -> None:
+        flask.g.proxy = proxy.get_proxy()
+
+    @bp.get('/authorize')
+    @flask_campus.unpack_request
+    def authorize(
+            target: schema.Url,
+            prompt: Literal["select_account"] | None = None
+    ) -> werkzeug.Response:
+        """Redirect to GitHub OAuth authorization endpoint."""
+        return flask.g.proxy.redirect_for_authorization(target, prompt)
+
+    @bp.get('/callback')
+    def callback() -> werkzeug.Response:
+        """Handle a GitHub OAuth callback request."""
+        callback_payload = flask_campus.get_request_payload()
+        if "error" in callback_payload:
+            # TODO: For testing - display error instead of redirecting
+            # This should be replaced with proper error handling that redirects to target
+            error_html = f"""
+            <html>
+            <head><title>OAuth Error</title></head>
+            <body>
+                <h1>OAuth Error</h1>
+                <p><strong>Error:</strong> {callback_payload.get('error')}</p>
+                <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
+                <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
+                <hr>
+                <p><strong>All callback parameters:</strong></p>
+                <pre>{callback_payload}</pre>
+            </body>
+            </html>
+            """
+            return flask.Response(error_html, status=400, mimetype='text/html')
+        else:
+            return flask_campus.unpack_into(success_callback,
+                                            **callback_payload)
+
+    def success_callback(
+            state: str,
+            code: str,
+            scope: str,
+            **kwargs: str
+    ) -> werkzeug.Response:
+        """Handle a Github OAuth callback request."""
+        return flask.g.proxy.handle_callback(
+            state,
+            code,
+            scope,
+            **kwargs
+        )
+
     app.register_blueprint(bp)
-
-
-@bp.before_request
-def before_request() -> None:
-    flask.g.proxy = proxy.get_proxy()
-
-
-@bp.get('/authorize')
-@flask_campus.unpack_request
-def authorize(
-        target: schema.Url,
-        prompt: Literal["select_account"] | None = None
-) -> werkzeug.Response:
-    """Redirect to GitHub OAuth authorization endpoint."""
-    return flask.g.proxy.redirect_for_authorization(target, prompt)
-
-
-@bp.get('/callback')
-def callback() -> werkzeug.Response:
-    """Handle a GitHub OAuth callback request."""
-    callback_payload = flask_campus.get_request_payload()
-    if "error" in callback_payload:
-        # TODO: For testing - display error instead of redirecting
-        # This should be replaced with proper error handling that redirects to target
-        error_html = f"""
-        <html>
-        <head><title>OAuth Error</title></head>
-        <body>
-            <h1>OAuth Error</h1>
-            <p><strong>Error:</strong> {callback_payload.get('error')}</p>
-            <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
-            <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
-            <hr>
-            <p><strong>All callback parameters:</strong></p>
-            <pre>{callback_payload}</pre>
-        </body>
-        </html>
-        """
-        return flask.Response(error_html, status=400, mimetype='text/html')
-    else:
-        return flask_campus.unpack_into(success_callback,
-                                        **callback_payload)
-
-
-def success_callback(
-        state: str,
-        code: str,
-        scope: str,
-        **kwargs: str
-) -> werkzeug.Response:
-    """Handle a Github OAuth callback request."""
-    return flask.g.proxy.handle_callback(
-        state,
-        code,
-        scope,
-        **kwargs
-    )

--- a/campus/auth/oauth_proxy/google/__init__.py
+++ b/campus/auth/oauth_proxy/google/__init__.py
@@ -6,10 +6,10 @@ Reference: https://developers.google.com/identity/protocols/oauth2/web-server
 
 Google OAuth 2.0 Authorization Flow Diagram:
 
-+--------+        (A)        +---------+ 
++--------+        (A)        +---------+
 |        |------------------>| Google  |
-|        |   Auth Request    |         | 
-|        |                   +---------+ 
+|        |   Auth Request    |         |
+|        |                   +---------+
 |        |        (B)        +---------+
 |        | +-----------------|         |
 |  User  | +---------------->|         |     (C)       +-----------+
@@ -50,77 +50,76 @@ logger = logging.getLogger(__name__)
 PROMPT_OPTION = Literal["consent", "login", "none", "select_account"]
 PROVIDER = 'google'
 
-bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
-
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialise auth routes with the given Flask app/blueprint."""
-    app.register_blueprint(bp)
+    """Initialise auth routes with the given Flask app/blueprint.
 
-
-@bp.before_request
-def before_request() -> None:
-    flask.g.proxy = proxy.get_proxy()
-
-
-@bp.get('/authorize')
-@flask_campus.unpack_request
-def authorize(
-        target: schema.Url,
-        hd: str | None = "nyjc.edu.sg",
-        login_hint: schema.Email | None = None,
-        prompt: PROMPT_OPTION | None = None,
-) -> werkzeug.Response:
-    """Prepares the Google OAuth authorization URL and redirects to it.
+    Creates a fresh blueprint each time to support test isolation.
     """
-    return flask.g.proxy.redirect_for_authorization(
-        target,
-        hd=hd,
-        login_hint=login_hint,
-        prompt=prompt
-    )
+    bp = flask.Blueprint(PROVIDER, __name__, url_prefix=f'/{PROVIDER}')
 
+    @bp.before_request
+    def before_request() -> None:
+        flask.g.proxy = proxy.get_proxy()
 
-@bp.get('/callback')
-def callback() -> werkzeug.Response:
-    """Handles the Google OAuth callback request.
-
-    Dispatches to success or error handlers based on payload type.
-    """
-    callback_payload = flask_campus.get_request_payload()
-    if "error" in callback_payload:
-        # TODO: For testing - display error instead of redirecting
-        # This should be replaced with proper error handling that redirects to target
-        error_html = f"""
-        <html>
-        <head><title>OAuth Error</title></head>
-        <body>
-            <h1>OAuth Error</h1>
-            <p><strong>Error:</strong> {callback_payload.get('error')}</p>
-            <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
-            <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
-            <hr>
-            <p><strong>All callback parameters:</strong></p>
-            <pre>{callback_payload}</pre>
-        </body>
-        </html>
+    @bp.get('/authorize')
+    @flask_campus.unpack_request
+    def authorize(
+            target: schema.Url,
+            hd: str | None = "nyjc.edu.sg",
+            login_hint: schema.Email | None = None,
+            prompt: PROMPT_OPTION | None = None,
+    ) -> werkzeug.Response:
+        """Prepares the Google OAuth authorization URL and redirects to it.
         """
-        return flask.Response(error_html, status=400, mimetype='text/html')
-    else:
-        return flask_campus.unpack_into(success_callback,
-                                        **callback_payload)
+        return flask.g.proxy.redirect_for_authorization(
+            target,
+            hd=hd,
+            login_hint=login_hint,
+            prompt=prompt
+        )
 
+    @bp.get('/callback')
+    def callback() -> werkzeug.Response:
+        """Handles the Google OAuth callback request.
 
-def success_callback(
-        state: str,
-        code: str,
-        scope: str,
-        **kwargs: str
-) -> werkzeug.Response:
-    """Handle a Google OAuth callback request."""
-    return flask.g.proxy.handle_consent_callback(
-        state,
-        code,
-        scope,
-        **kwargs
-    )
+        Dispatches to success or error handlers based on payload type.
+        """
+        callback_payload = flask_campus.get_request_payload()
+        if "error" in callback_payload:
+            # TODO: For testing - display error instead of redirecting
+            # This should be replaced with proper error handling that redirects to target
+            error_html = f"""
+            <html>
+            <head><title>OAuth Error</title></head>
+            <body>
+                <h1>OAuth Error</h1>
+                <p><strong>Error:</strong> {callback_payload.get('error')}</p>
+                <p><strong>Description:</strong> {callback_payload.get('error_description', 'N/A')}</p>
+                <p><strong>Error URI:</strong> {callback_payload.get('error_uri', 'N/A')}</p>
+                <hr>
+                <p><strong>All callback parameters:</strong></p>
+                <pre>{callback_payload}</pre>
+            </body>
+            </html>
+            """
+            return flask.Response(error_html, status=400, mimetype='text/html')
+        else:
+            return flask_campus.unpack_into(success_callback,
+                                            **callback_payload)
+
+    def success_callback(
+            state: str,
+            code: str,
+            scope: str,
+            **kwargs: str
+    ) -> werkzeug.Response:
+        """Handle a Google OAuth callback request."""
+        return flask.g.proxy.handle_consent_callback(
+            state,
+            code,
+            scope,
+            **kwargs
+        )
+
+    app.register_blueprint(bp)

--- a/campus/auth/routes/__init__.py
+++ b/campus/auth/routes/__init__.py
@@ -6,8 +6,8 @@ This package contains all HTTP route definitions organized by functionality:
 - vault.py: Secret management operations (/vault/*)
 - client.py: Client management operations (/client/*)
 
-Each module defines a Flask blueprint with appropriate URL prefixes and
-authentication decorators.
+Each module defines route functions that can be attached to blueprints
+dynamically. This allows creating fresh blueprints for test isolation.
 """
 
 __all__ = [
@@ -26,6 +26,17 @@ from campus.common.errors import auth_errors
 
 from .. import resources
 from . import clients, credentials, logins, root, sessions, users, vaults
+
+# Route modules that require authentication
+_AUTHENTICATED_ROUTE_MODULES = [
+    clients,
+    credentials,
+    logins,
+    root,
+    sessions,
+    users,
+    vaults,
+]
 
 
 def authenticate() -> tuple[dict[str, str], int] | None:
@@ -74,25 +85,13 @@ def authenticate() -> tuple[dict[str, str], int] | None:
 
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialize the auth routes with the given Flask app or
-    blueprint.
-    
+    """Initialize the auth routes with the given Flask app or blueprint.
+
+    Creates fresh blueprints each time to support test isolation.
     Authentication is applied to each blueprint individually to avoid
     affecting OAuth proxy routes which should be publicly accessible.
     """
-    # Apply authentication to each blueprint that requires it
-    clients.bp.before_request(authenticate)
-    credentials.bp.before_request(authenticate)
-    logins.bp.before_request(authenticate)
-    root.bp.before_request(authenticate)
-    sessions.bp.before_request(authenticate)
-    users.bp.before_request(authenticate)
-    vaults.bp.before_request(authenticate)
-    
-    app.register_blueprint(clients.bp)
-    app.register_blueprint(credentials.bp)
-    app.register_blueprint(logins.bp)
-    app.register_blueprint(root.bp)
-    app.register_blueprint(sessions.bp)
-    app.register_blueprint(users.bp)
-    app.register_blueprint(vaults.bp)
+    for module in _AUTHENTICATED_ROUTE_MODULES:
+        blueprint = module.create_blueprint()
+        blueprint.before_request(authenticate)
+        app.register_blueprint(blueprint)

--- a/campus/auth/routes/clients.py
+++ b/campus/auth/routes/clients.py
@@ -200,6 +200,30 @@ def check_client_access(
     return {"vault": vault, "permission": has_access}, 200
 
 
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('clients', __name__, url_prefix='/clients')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/", "new", new, methods=["POST"])
+    new_bp.add_url_rule("/", "list_all", list_all, methods=["GET"])
+    new_bp.add_url_rule("/<client_id>/", "delete_client", delete_client, methods=["DELETE"])
+    new_bp.add_url_rule("/<client_id>/", "get_client", get_client, methods=["GET"])
+    new_bp.add_url_rule("/<client_id>/revoke", "revoke_client", revoke_client, methods=["POST"])
+    new_bp.add_url_rule("/<client_id>/", "update_client", update_client, methods=["PATCH"])
+    new_bp.add_url_rule("/<client_id>/access/", "get_client_access", get_client_access, methods=["GET"])
+    new_bp.add_url_rule("/<client_id>/access/check", "check_client_access", check_client_access, methods=["GET"])
+    new_bp.add_url_rule("/<client_id>/access/grant", "grant_client_access", grant_client_access, methods=["POST"])
+    new_bp.add_url_rule("/<client_id>/access/revoke", "revoke_client_access", revoke_client_access, methods=["POST"])
+    new_bp.add_url_rule("/<client_id>/access/", "update_client_access", update_client_access, methods=["PATCH"])
+
+    return new_bp
+
+
 @bp.post("/<client_id>/access/grant")
 @flask_campus.unpack_request
 def grant_client_access(

--- a/campus/auth/routes/credentials.py
+++ b/campus/auth/routes/credentials.py
@@ -137,3 +137,21 @@ def new_credentials(
         expiry_seconds=expiry_seconds
     )
     return credentials.to_resource(), 201
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('credentials', __name__, url_prefix='/credentials')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/<provider>/", "get_by_token", get_by_token, methods=["GET"])
+    new_bp.add_url_rule("/<provider>/<user_id>", "delete_by_user", delete_by_user, methods=["DELETE"])
+    new_bp.add_url_rule("/<provider>/<user_id>", "get_by_user", get_by_user, methods=["GET"])
+    new_bp.add_url_rule("/<provider>/<user_id>", "update_credentials", update_credentials, methods=["PATCH"])
+    new_bp.add_url_rule("/<provider>/<user_id>", "new_credentials", new_credentials, methods=["POST"])
+
+    return new_bp

--- a/campus/auth/routes/logins.py
+++ b/campus/auth/routes/logins.py
@@ -90,3 +90,20 @@ def update(
     )
     get_yapper().emit('campus.logins.update', {"session_id": session_id})
     return loginsession.to_resource(), 200
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('logins', __name__, url_prefix='/logins')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/", "new", new, methods=["POST"])
+    new_bp.add_url_rule("/<session_id>/", "delete", delete, methods=["DELETE"])
+    new_bp.add_url_rule("/<session_id>/", "get", get, methods=["GET"])
+    new_bp.add_url_rule("/<session_id>/", "update", update, methods=["PATCH"])
+
+    return new_bp

--- a/campus/auth/routes/root.py
+++ b/campus/auth/routes/root.py
@@ -100,3 +100,17 @@ def authenticate_token(token: str) -> flask_campus.JsonResponse:
         }
         status_code = 200
     return resp_json, status_code
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('root', __name__, url_prefix='/root')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/", "authenticate", authenticate, methods=["POST"])
+
+    return new_bp

--- a/campus/auth/routes/sessions.py
+++ b/campus/auth/routes/sessions.py
@@ -190,3 +190,22 @@ def update_provider_session(
         }
     )
     return {}, 200
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('sessions', __name__, url_prefix='/sessions')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/sweep", "sweep", sweep, methods=["POST"])
+    new_bp.add_url_rule("/<provider>/authorization_code", "get_by_authorization_code", get_by_authorization_code, methods=["POST"])
+    new_bp.add_url_rule("/<provider>/", "new_provider_session", new_provider_session, methods=["POST"])
+    new_bp.add_url_rule("/<provider>/<session_id>/", "delete_provider_session", delete_provider_session, methods=["DELETE"])
+    new_bp.add_url_rule("/<provider>/<session_id>/", "get_provider_session", get_provider_session, methods=["GET"])
+    new_bp.add_url_rule("/<provider>/<session_id>/", "update_provider_session", update_provider_session, methods=["PATCH"])
+
+    return new_bp

--- a/campus/auth/routes/users.py
+++ b/campus/auth/routes/users.py
@@ -105,3 +105,22 @@ def update() -> flask_campus.JsonResponse:
     Returns: User
     """
     return {}, 501
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('users', __name__, url_prefix='/users')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/", "get_all", get_all, methods=["GET"])
+    new_bp.add_url_rule("/", "new", new, methods=["POST"])
+    new_bp.add_url_rule("/<user_id>/activate", "activate", activate, methods=["POST"])
+    new_bp.add_url_rule("/<user_id>", "delete_user", delete_user, methods=["DELETE"])
+    new_bp.add_url_rule("/<user_id>", "get", get, methods=["GET"])
+    new_bp.add_url_rule("/<user_id>", "update", update, methods=["PATCH"])
+
+    return new_bp

--- a/campus/auth/routes/vaults.py
+++ b/campus/auth/routes/vaults.py
@@ -83,3 +83,20 @@ def set(label: str, key: str, value: str) -> flask_campus.JsonResponse:
     vault_resource[label][key] = value
     get_yapper().emit('campus.vaults.key.update', {"label": label, "key": key})
     return {"key": value}, 200
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('vaults', __name__, url_prefix='/vaults')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/<label>/", "keys", keys, methods=["GET"])
+    new_bp.add_url_rule("/<label>/<key>", "delete", delete, methods=["DELETE"])
+    new_bp.add_url_rule("/<label>/<key>", "get", get, methods=["GET"])
+    new_bp.add_url_rule("/<label>/<key>", "set", set, methods=["POST"])
+
+    return new_bp

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -30,11 +30,13 @@ class ServiceManager:
     _shared_instance = None
     _shared_setup_done = False
 
-    def __init__(self, shared=True):
+    def __init__(self, shared=False):
         """Initialize ServiceManager.
 
         Args:
-            shared: Whether to reuse shared instance across test suites
+            shared: Whether to reuse shared instance across test suites.
+                    Defaults to False to create fresh Flask apps per test class
+                    for better test isolation.
         """
         self.auth_app: Optional[object] = None
         self.apps_app: Optional[object] = None
@@ -54,9 +56,9 @@ class ServiceManager:
         initialization in proper dependency order: auth → storage → yapper → api.
 
         Note:
-            Resetting test storage at the start ensures each test class gets
-            a clean storage slate. Flask apps remain shared to avoid blueprint
-            re-registration errors, but storage is fully reset.
+            With shared=False (the default), creates fresh Flask apps with
+            fresh blueprints for each test class. This ensures full test
+            isolation at the cost of slightly slower test execution.
 
         Returns:
             ServiceManager: Self for method chaining
@@ -158,8 +160,8 @@ class ServiceManager:
     def close(self):
         """Clean up service instances and resources.
 
-        Always cleans up auth client and credentials. For shared instances,
-        the Flask apps are preserved to avoid blueprint re-registration errors.
+        Always cleans up auth client and credentials. With shared=False,
+        also cleans up Flask apps for full isolation.
         """
         # Always clean up auth client regardless of shared mode
         self._cleanup_auth_client()
@@ -170,8 +172,8 @@ class ServiceManager:
         if env.CLIENT_SECRET is not None:
             delattr(env, "CLIENT_SECRET")
 
-        # For shared instances, preserve apps for subsequent test classes
-        # to avoid "blueprint already registered" errors
+        # For non-shared instances, clean up apps for full isolation
+        # This is now the default behavior
         if not self._shared:
             if self.auth_app is not None:
                 self.auth_app = None
@@ -253,12 +255,13 @@ def init():
         manager.close()
 
 
-def create_service_manager(shared=True):
+def create_service_manager(shared=False):
     """Factory function to create a new ServiceManager.
 
     Args:
-        shared: If True, reuse shared instance across test suites.
-               If False, create independent instance.
+        shared: If True, reuse shared instance across test suites (faster).
+               If False (default), create independent instance with fresh
+               Flask apps for each test class (better isolation).
 
     Returns:
         ServiceManager: New or shared service manager

--- a/tests/integration/test_wsgi.py
+++ b/tests/integration/test_wsgi.py
@@ -6,12 +6,12 @@ from tests.fixtures import services
 from campus.common import env
 
 
-# TODO: Fix wsgi test - Flask blueprints can't have before_request added after
-# being registered. The test imports wsgi.py which calls main.create_app(),
-# which calls init_app() multiple times on the same module-level blueprints.
-# This test should be re-enabled after fixing the blueprint initialization.
-@unittest.skip("Flask blueprint before_request registration issue")
 class TestWSGI(unittest.TestCase):
+    """Test WSGI entry point with fresh Flask apps per test class.
+
+    Previously skipped due to blueprint re-registration issues.
+    Fixed by creating fresh blueprints in init_app() (Option B).
+    """
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Summary

Implements **Option B** from issue #337: create new Flask apps per test class for better test isolation. This resolves the blueprint re-registration issue that caused `test_wsgi` to be skipped.

## Problem

Flask blueprints with module-level `@bp.before_request` decorators cannot be re-registered after being attached to a Flask app. This blocked integration tests from creating fresh Flask apps between test classes.

## Solution

1. **OAuth proxy modules** ([google](campus/auth/oauth_proxy/google/__init__.py), [github](campus/auth/oauth_proxy/github/__init__.py), [discord](campus/auth/oauth_proxy/discord/__init__.py), [campus](campus/auth/oauth_proxy/campus/__init__.py))
   - Move blueprint creation inside `init_app()` for fresh instances each call

2. **Auth route modules** ([clients](campus/auth/routes/clients.py), [credentials](campus/auth/routes/credentials.py), [logins](campus/auth/routes/logins.py), [sessions](campus/auth/routes/sessions.py), [users](campus/auth/routes/users.py), [vaults](campus/auth/routes/vaults.py), [root](campus/auth/routes/root.py))
   - Add `create_blueprint()` factory functions
   - Manually register routes using `add_url_rule()`

3. **[routes/__init__.py](campus/auth/routes/__init__.py)** - Refactored to use a loop with `create_blueprint()`

4. **[services.py](tests/fixtures/services.py)** - Changed default `shared=False` for fresh Flask apps per test class

5. **[test_wsgi.py](tests/integration/test_wsgi.py)** - Removed `@unittest.skip` decorator

## Performance Impact

| Metric | Before (shared=True) | After (shared=False) | Change |
|--------|---------------------|---------------------|--------|
| Real time | 1.41s | 1.47s | +0.06s (+4.5%) |
| Tests skipped | 1 | 0 | -1 |

The ~4.5% wall-clock increase is negligible for the benefit of full test isolation.

## Test Plan

All integration tests pass:
- 18 tests in `tests/integration/` - OK (including previously skipped `test_wsgi`)
- 18 tests in `tests/integration/api/` - OK

Closes #337