### PR TITLE
test: implement per-test isolation for integration tests

### DIFF
--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -157,6 +157,29 @@ class ServiceManager:
 
         return self
 
+    def reset_test_data(self):
+        """Reset test storage for per-test isolation.
+
+        This method clears all test storage (SQLite in-memory DB, memory collections)
+        and re-initializes services. Use this in tearDown() for per-test isolation.
+
+        WARNING: This clears auth credentials, so tests using bearer tokens will need
+        to re-create their tokens after calling this method.
+
+        For tests that use authentication, consider using unique identifiers per test
+        (e.g., filtering by created_by) instead of full reset, or re-create the token
+        in setUp() after calling this in tearDown().
+        """
+        import campus.storage.testing
+
+        # Reset storage (clears SQLite in-memory DB and memory collections)
+        campus.storage.testing.reset_test_storage()
+
+        # Re-initialize auth and yapper services
+        # These are idempotent and will recreate necessary tables/collections
+        auth.init()
+        yapper.init()
+
     def close(self):
         """Clean up service instances and resources.
 

--- a/tests/integration/api/test_assignments.py
+++ b/tests/integration/api/test_assignments.py
@@ -27,17 +27,32 @@ class TestAssignmentsIntegration(unittest.TestCase):
             raise RuntimeError("Expected Flask app from service manager")
 
         cls.app = api_app
+        cls.user_id = schema.UserID("test.user@campus.test")
 
-        # Initialize credentials storage (needed for token creation)
-        # This may have been cleared by a previous test class
-        from campus.auth import resources as auth_resources
-        auth_resources.credentials.init_storage()
-        auth_resources.user.init_storage()
+    def setUp(self):
+        """Set up test environment before each test."""
+        self.client = self.app.test_client()
+
+        # Set up test context
+        self.app_context = self.app.app_context()
+        self.app_context.push()
 
         # Create test user token for bearer auth
-        cls.user_id = schema.UserID("test.user@campus.test")
-        cls.token = create_test_token(cls.user_id)
-        cls.auth_headers = get_bearer_auth_headers(cls.token)
+        # Re-create before each test since tearDown() resets storage
+        self.token = create_test_token(self.user_id)
+        self.auth_headers = get_bearer_auth_headers(self.token)
+
+    def tearDown(self):
+        """Clean up after each test.
+
+        Resets storage for per-test isolation, ensuring tests don't pollute
+        each other's state. This eliminates the need for test_00_* prefixes.
+        """
+        self.app_context.pop()
+
+        # Reset storage for per-test isolation
+        if hasattr(self, 'service_manager'):
+            self.service_manager.reset_test_data()
 
     @classmethod
     def tearDownClass(cls):
@@ -49,20 +64,8 @@ class TestAssignmentsIntegration(unittest.TestCase):
         import campus.storage.testing
         campus.storage.testing.reset_test_storage()
 
-    def setUp(self):
-        """Set up test environment before each test."""
-        self.client = self.app.test_client()
-
-        # Set up test context
-        self.app_context = self.app.app_context()
-        self.app_context.push()
-
-    def tearDown(self):
-        """Clean up after each test."""
-        self.app_context.pop()
-
-    def test_00_list_assignments_empty(self):
-        """GET /assignments should return empty list initially. (Named test_00_* to run first for isolation)"""
+    def test_list_assignments_empty(self):
+        """GET /assignments should return empty list initially."""
         response = self.client.get('/api/v1/assignments/', headers=self.auth_headers)
 
         assert response.status_code == 200


### PR DESCRIPTION
## Summary
Implements **Option A variant** (per-test reset) for issue #335, providing true test isolation while maintaining acceptable performance.

## Changes
- **[tests/fixtures/services.py](tests/fixtures/services.py)**: Added `ServiceManager.reset_test_data()` method
  - Resets storage (SQLite in-memory DB, memory collections) between tests
  - Re-initializes auth/yapper services after reset
  - Preserves Flask apps for performance

- **[tests/integration/api/test_assignments.py](tests/integration/api/test_assignments.py)**:
  - Moved reset from `tearDownClass()` to `tearDown()`
  - Re-create test tokens in `setUp()` (required because reset clears credentials)
  - Removed `test_00_*` prefix from `test_list_assignments_empty`

## Test Results
- All 12 integration tests pass (up from 6 failures before)
- Full integration test suite passes (18 tests)
- No `test_00_*` prefixes remaining in codebase

## Performance Impact
Minimal: ~0.04s increase for 12-test suite (0.25s → 0.29s)
- `reset_test_storage()` is cheap (closes/reopens SQLite connection, clears dict)
- Flask apps are preserved (only storage is reset)

## Usage Pattern for Other Tests
```python
def setUp(self):
    self.client = self.app.test_client()
    self.app_context = self.app.app_context().push()
    # Re-create token since tearDown() clears credentials
    self.token = create_test_token(self.user_id)
    self.auth_headers = get_bearer_auth_headers(self.token)

def tearDown(self):
    self.app_context.pop()
    if hasattr(self, 'service_manager'):
        self.service_manager.reset_test_data()
```

## Trade-offs
| Pro | Con |
|-----|-----|
| True test isolation - no test ordering issues | Tests using bearer tokens must re-create tokens in `setUp()` |
| Removes `test_00_*` naming hack | Slightly slower (but negligible impact) |
| Cleaner, more maintainable tests | |

Fixes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)