### PR TITLE
fix(auth): improve error handler to return JSON or redirect based on request type (#386)

### DIFF
--- a/campus/common/errors/__init__.py
+++ b/campus/common/errors/__init__.py
@@ -38,23 +38,72 @@ def get_caller() -> str:
 
 def handle_authorization_error(
         err: auth_errors.AuthorizationError
-) -> werkzeug.Response:
+) -> werkzeug.Response | tuple[JsonDict, int]:
     """Handle OAuth authorization request errors.
 
-    This function is used to handle OAuth errors and return
-    standardised JSON responses.
+    This function handles OAuth errors and returns appropriate responses:
+    - For API requests (JSON Accept header or /auth/v1/* paths): JSON error
+    - For OAuth browser flows: HTTP redirect (RFC 6749)
+
+    In development mode, raises BadRequest for ambiguous requests.
     """
     module = get_caller()
     logger.exception("OAuthError in %s: %s", module, err)
-    err_dict = err.to_dict()
-    # OAuth errors follow RFC 6749, not the API error spec
-    # No production cleanup needed for OAuth redirect errors
-    return flask.redirect(
-        url.add_query(
-            err.redirect_uri or flask.request.base_url,
-            **err_dict
+
+    # Determine if this is an API request (expects JSON) or OAuth browser flow (expects redirect)
+    accept_header = flask.request.headers.get("Accept", "")
+    is_json_accept = "application/json" in accept_header
+    is_api_path = flask.request.path.startswith("/auth/v1/")
+    has_redirect_uri = err.redirect_uri is not None
+
+    # API request detection: JSON Accept header or API path prefix
+    is_api_request = is_json_accept or is_api_path
+
+    # OAuth browser flow detection: has redirect_uri and not an API request
+    is_oauth_flow = has_redirect_uri and not is_api_request
+
+    if is_api_request:
+        # API request - return JSON error response
+        # Use envelope format for API consistency
+        err_dict = err.to_dict(envelope_format=True)
+        from campus.common import devops
+        # Remove details in production for security reasons
+        if devops.ENV == devops.PRODUCTION:
+            err_dict["error"].pop("details", None)
+        # Return appropriate status code from the error
+        return err_dict, err.status_code
+
+    elif is_oauth_flow:
+        # OAuth browser flow - return redirect (RFC 6749)
+        err_dict = err.to_dict()
+        # OAuth errors follow RFC 6749, not the API error spec
+        # No production cleanup needed for OAuth redirect errors
+        return flask.redirect(
+            url.add_query(
+                err.redirect_uri or flask.request.base_url,
+                **err_dict
+            )
         )
-    )
+
+    else:
+        # Ambiguous request - in development, raise an error to help debugging
+        from campus.common import devops
+        if devops.ENV == devops.PRODUCTION:
+            # In production, default to JSON for safety
+            err_dict = err.to_dict(envelope_format=True)
+            return err_dict, err.status_code
+        else:
+            # In development, raise to help identify the issue
+            raise flask.abort(
+                400,
+                description=(
+                    f"Ambiguous authorization error: "
+                    f"Accept={accept_header!r}, path={flask.request.path!r}, "
+                    f"has_redirect_uri={has_redirect_uri}. "
+                    f"Please set Accept: application/json for API requests "
+                    f"or provide redirect_uri for OAuth flows."
+                )
+            )
 
 def handle_api_error(err: api_errors.APIError) -> tuple[JsonDict, int]:
     """Handle API errors.

--- a/campus/common/errors/auth_errors.py
+++ b/campus/common/errors/auth_errors.py
@@ -66,11 +66,11 @@ def raise_from_json(error_json: dict[str, str]) -> NoReturn:
 
 class AuthorizationError(base.OAuthError):
     """OAuth Authorization Errors.
-    
+
     From RFC 6749 Section 4.1.2.1
     https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
     """
-    error: base.AuthResponseErrorType  # type: ignore
+    error: base.AuthResponseErrorType = "invalid_request"  # type: ignore
     error_uri = None
     redirect_uri: str | None
 
@@ -82,8 +82,6 @@ class AuthorizationError(base.OAuthError):
     ) -> None:
         if "redirect_uri" in details:
             redirect_uri = details.pop("redirect_uri")
-        else:
-            redirect_uri = None
         super().__init__(error_description, **details)
         self.redirect_uri = redirect_uri
 

--- a/tests/unit/common/test_auth_error_responses.py
+++ b/tests/unit/common/test_auth_error_responses.py
@@ -191,5 +191,125 @@ class TestOAuthErrorDetails(unittest.TestCase):
         self.assertEqual(response["error"]["details"]["attempt_count"], 3)
 
 
+class TestAuthorizationErrorHandler(unittest.TestCase):
+    """handle_authorization_error must return appropriate responses based on request type."""
+
+    def setUp(self):
+        """Set up Flask app for testing error handler."""
+        # Lazy import to avoid storage initialization issues
+        from campus.common.errors import init_app
+        from campus.common.errors.auth_errors import (
+            AuthorizationError,
+            UnauthorizedClientError,
+        )
+        from campus.common import devops
+
+        import flask
+        self.app = flask.Flask(__name__)
+        init_app(self.app)
+        self.app.config["TESTING"] = True
+        self.UnauthorizedClientError = UnauthorizedClientError
+        self.AuthorizationError = AuthorizationError
+        self.devops = devops
+
+        # Save original ENV
+        self.original_env = os.environ.get("ENV")
+
+    def tearDown(self):
+        """Restore original ENV."""
+        if self.original_env:
+            os.environ["ENV"] = self.original_env
+        elif "ENV" in os.environ:
+            del os.environ["ENV"]
+
+    def test_json_accept_header_returns_json_error(self):
+        """API requests with JSON Accept header return JSON error response."""
+        err = self.UnauthorizedClientError("Invalid credentials")
+
+        with self.app.test_request_context(
+            "/auth/v1/sessions/test",
+            headers={"Accept": "application/json"}
+        ):
+            from campus.common.errors import handle_authorization_error
+            response, status_code = handle_authorization_error(err)
+
+            self.assertEqual(status_code, 400)
+            self.assertIn("error", response)
+            self.assertEqual(response["error"]["code"], "AUTH_UNAUTHORIZED_CLIENT")
+            self.assertEqual(response["error"]["message"], "Invalid credentials")
+
+    def test_api_path_returns_json_error(self):
+        """API requests under /auth/v1/* return JSON error response."""
+        err = self.UnauthorizedClientError("Invalid credentials")
+
+        with self.app.test_request_context(
+            "/auth/v1/clients/test",
+            headers={"Accept": "text/html"}  # Not JSON, but path is API
+        ):
+            from campus.common.errors import handle_authorization_error
+            response, status_code = handle_authorization_error(err)
+
+            self.assertEqual(status_code, 400)
+            self.assertIn("error", response)
+            self.assertEqual(response["error"]["code"], "AUTH_UNAUTHORIZED_CLIENT")
+
+    def test_oauth_flow_with_redirect_uri_returns_redirect(self):
+        """OAuth browser flows with redirect_uri return HTTP redirect."""
+        err = self.AuthorizationError(
+            "Invalid credentials",
+            redirect_uri="https://example.com/callback"
+        )
+
+        with self.app.test_request_context(
+            "/oauth/authorize",  # Not an API path
+            headers={"Accept": "text/html"}
+        ):
+            from campus.common.errors import handle_authorization_error
+            response = handle_authorization_error(err)
+
+            # Should be a Flask redirect response
+            self.assertIn("location", response.headers)
+            self.assertIn("error=invalid_request", response.headers["location"])
+
+    def test_ambiguous_request_in_development_raises_400(self):
+        """Ambiguous requests (no JSON Accept, no API path, no redirect_uri) raise 400 in development."""
+        os.environ["ENV"] = "development"
+
+        err = self.UnauthorizedClientError("Invalid credentials")
+
+        with self.app.test_request_context(
+            "/some/unknown/path",
+            headers={"Accept": "text/html"}
+        ):
+            from campus.common.errors import handle_authorization_error
+            from werkzeug.exceptions import BadRequest
+
+            with self.assertRaises(BadRequest) as context:
+                handle_authorization_error(err)
+
+            self.assertIn("Ambiguous authorization error", str(context.exception))
+
+    def test_ambiguous_request_in_production_returns_json(self):
+        """Ambiguous requests default to JSON in production for safety."""
+        # Use devops.PRODUCTION constant for reliable check
+        original = self.devops.ENV
+        self.devops.ENV = self.devops.PRODUCTION
+
+        try:
+            err = self.UnauthorizedClientError("Invalid credentials")
+
+            with self.app.test_request_context(
+                "/some/unknown/path",
+                headers={"Accept": "text/html"}
+            ):
+                from campus.common.errors import handle_authorization_error
+                response, status_code = handle_authorization_error(err)
+
+                self.assertEqual(status_code, 400)
+                self.assertIn("error", response)
+        finally:
+            self.devops.ENV = original
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `handle_authorization_error` now returns JSON for API requests and HTTP redirects for OAuth browser flows
- API requests detected by: `/auth/v1/*` path prefix OR `Accept: application/json` header
- OAuth flows detected by: presence of `redirect_uri` AND not an API request
- Sets default value for `AuthorizationError.error` attribute

## Changes
- `campus/common/errors/__init__.py`: Enhanced error handler with request type detection
- `campus/common/errors/auth_errors.py`: Added default value for `error` attribute
- `tests/unit/common/test_auth_error_responses.py`: Added tests for new behavior

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)