### PR TITLE
fix: import env at runtime to avoid capturing module reference

### DIFF
--- a/campus/auth/oauth_proxy/campus/proxy.py
+++ b/campus/auth/oauth_proxy/campus/proxy.py
@@ -5,10 +5,12 @@ Campus OAuth2 proxy implementation.
 
 __all__ = ["CampusAuthProxy", "get_proxy"]
 
+import functools
+
 import flask
 import werkzeug
 
-from campus.common import env, schema, webauth
+from campus.common import schema, webauth
 from campus.common.utils import url
 
 from .. import base
@@ -28,14 +30,12 @@ def get_proxy() -> "CampusAuthProxy":
     return CampusAuthProxy()
 
 
-class CampusAuthProxy(base.AuthProxy):
-    """Campus OAuth2 provider implementation."""
-    provider = PROVIDER
-    title = "Campus OAuth2 Authentication API"
-    description = "OAuth2 authentication endpoints for Campus integration"
-    version = "2025-11-05"
-    openapi_version = "3.0.3"
-    _oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
+def _create_oauth2_scheme():
+    """Create OAuth2 scheme with runtime env access."""
+    # Import env only at runtime to avoid capturing module instead of
+    # EnvironmentProxy during class definition
+    from campus.common import env
+    return webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
         client_id=env.CLIENT_ID,
         redirect_uri=REDIRECT_URI,
         provider=PROVIDER,
@@ -49,9 +49,31 @@ class CampusAuthProxy(base.AuthProxy):
         headers={"Accept": "application/json"},
     )
 
+
+@functools.lru_cache(maxsize=None)
+def _get_oauth2_scheme():
+    """Get cached OAuth2 scheme instance."""
+    return _create_oauth2_scheme()
+
+
+class CampusAuthProxy(base.AuthProxy):
+    """Campus OAuth2 provider implementation."""
+    provider = PROVIDER
+    title = "Campus OAuth2 Authentication API"
+    description = "OAuth2 authentication endpoints for Campus integration"
+    version = "2025-11-05"
+    openapi_version = "3.0.3"
+
     def __init__(self) -> None:
+        # Import env only at runtime
+        from campus.common import env
         self._CLIENT_ID = env.CLIENT_ID
         self._CLIENT_SECRET = env.CLIENT_SECRET
+
+    @property
+    def _oauth2(self):
+        """Get OAuth2 scheme instance (cached)."""
+        return _get_oauth2_scheme()
 
     @property
     def authorization_url(self) -> schema.Url:

--- a/campus/auth/oauth_proxy/discord/proxy.py
+++ b/campus/auth/oauth_proxy/discord/proxy.py
@@ -10,7 +10,7 @@ from typing import Literal
 import flask
 import werkzeug
 
-from campus.common import env, schema, webauth
+from campus.common import schema, webauth
 from campus.common.errors import auth_errors
 import campus.config
 
@@ -18,8 +18,13 @@ from .. import base
 from ... import resources
 
 PROVIDER = "discord"
-REDIRECT_URI = schema.Url(env.HOSTNAME + f"/auth/{PROVIDER}/callback")
 SCOPE_SEP = " "
+
+
+def _get_redirect_uri() -> schema.Url:
+    """Get redirect URI with runtime env access."""
+    from campus.common import env
+    return schema.Url(env.HOSTNAME + f"/auth/{PROVIDER}/callback")
 
 
 def get_proxy() -> "DiscordAuthPoxy":
@@ -35,24 +40,26 @@ class DiscordAuthPoxy(base.AuthProxy):
     version = "10.0.0"
     openapi_version = "3.0.3"
     _headers = {"Accept": "application/json"}
-    _oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
-        provider=PROVIDER,
-        client_id=env.CLIENT_ID,
-        redirect_uri=REDIRECT_URI,
-        authorization_url=schema.Url(
-            "https://discord.com/oauth2/authorize"
-        ),
-        token_url=schema.Url("https://discord.com/api/oauth2/token"),
-        user_info_url=schema.Url(
-            "https://discord.com/api/users/@me"
-        ),
-        scopes=["identify", "email", "guilds"],
-        headers={"Accept": "application/json"},
-    )
     _PROMPT_OPTIONS = Literal["consent", "none"] | None
 
     def __init__(self) -> None:
         super().__init__()
+        # Import env at runtime and create OAuth2 scheme
+        from campus.common import env
+        self._oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
+            provider=PROVIDER,
+            client_id=env.CLIENT_ID,
+            redirect_uri=_get_redirect_uri(),
+            authorization_url=schema.Url(
+                "https://discord.com/oauth2/authorize"
+            ),
+            token_url=schema.Url("https://discord.com/api/oauth2/token"),
+            user_info_url=schema.Url(
+                "https://discord.com/api/users/@me"
+            ),
+            scopes=["identify", "email", "guilds"],
+            headers={"Accept": "application/json"},
+        )
 
     @property
     def authorization_url(self) -> schema.Url:

--- a/campus/auth/oauth_proxy/discord/proxy.py
+++ b/campus/auth/oauth_proxy/discord/proxy.py
@@ -90,7 +90,7 @@ class DiscordAuthPoxy(base.AuthProxy):
         """Redirect to GitHub OAuth2 authorization endpoint."""
         authsession = self.init_authsession(
             expiry_seconds=campus.config.DEFAULT_OAUTH_EXPIRY_MINUTES * 60,
-            redirect_uri=REDIRECT_URI,
+            redirect_uri=_get_redirect_uri(),
             scopes=self._oauth2.scopes,
             target=target
         )

--- a/campus/auth/oauth_proxy/github/proxy.py
+++ b/campus/auth/oauth_proxy/github/proxy.py
@@ -10,7 +10,7 @@ from typing import Literal
 import flask
 import werkzeug
 
-from campus.common import env, schema, webauth
+from campus.common import schema, webauth
 from campus.common.errors import auth_errors
 import campus.config
 
@@ -18,8 +18,13 @@ from .. import base
 from ... import resources
 
 PROVIDER = "github"
-REDIRECT_URI = schema.Url(env.HOSTNAME + f"/auth/{PROVIDER}/callback")
 SCOPE_SEP = " "
+
+
+def _get_redirect_uri() -> schema.Url:
+    """Get redirect URI with runtime env access."""
+    from campus.common import env
+    return schema.Url(env.HOSTNAME + f"/auth/{PROVIDER}/callback")
 
 
 def get_proxy() -> "GitHubAuthProxy":
@@ -35,22 +40,24 @@ class GitHubAuthProxy(base.AuthProxy):
         "OAuth2 authentication endpoints for GitHub integration with Campus")
     version = "2022-11-28"
     openapi_version = "3.0.3"
-    _oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
-        provider=PROVIDER,
-        client_id=env.CLIENT_ID,
-        redirect_uri=REDIRECT_URI,
-        authorization_url=schema.Url(
-            "https://github.com/login/oauth/authorize"),
-        token_url=schema.Url(
-            "https://github.com/login/oauth/access_token"),
-        user_info_url=schema.Url("https://api.github.com/user"),
-        scopes=["read:user", "read:email"],
-        headers={"Accept": "application/json"},
-    )
     _PROMPT_OPTIONS = Literal["select_account"] | None
 
     def __init__(self) -> None:
         super().__init__()
+        # Import env at runtime and create OAuth2 scheme
+        from campus.common import env
+        self._oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
+            provider=PROVIDER,
+            client_id=env.CLIENT_ID,
+            redirect_uri=_get_redirect_uri(),
+            authorization_url=schema.Url(
+                "https://github.com/login/oauth/authorize"),
+            token_url=schema.Url(
+                "https://github.com/login/oauth/access_token"),
+            user_info_url=schema.Url("https://api.github.com/user"),
+            scopes=["read:user", "read:email"],
+            headers={"Accept": "application/json"},
+        )
 
     @property
     def authorization_url(self) -> schema.Url:

--- a/campus/auth/oauth_proxy/github/proxy.py
+++ b/campus/auth/oauth_proxy/github/proxy.py
@@ -87,7 +87,7 @@ class GitHubAuthProxy(base.AuthProxy):
         """Redirect to GitHub OAuth2 authorization endpoint."""
         authsession = self.init_authsession(
             expiry_seconds=campus.config.DEFAULT_OAUTH_EXPIRY_MINUTES * 60,
-            redirect_uri=REDIRECT_URI,
+            redirect_uri=_get_redirect_uri(),
             scopes=self._oauth2.scopes,
             target=target
         )

--- a/campus/auth/oauth_proxy/google/proxy.py
+++ b/campus/auth/oauth_proxy/google/proxy.py
@@ -10,7 +10,7 @@ from typing import Literal
 import flask
 import werkzeug
 
-from campus.common import env, schema, webauth
+from campus.common import schema, webauth
 from campus.common.errors import auth_errors, token_errors
 from campus.common.utils import url
 import campus.config
@@ -20,8 +20,13 @@ from .. import base
 from ... import resources
 
 PROVIDER = "google"
-REDIRECT_URI = schema.Url(f"https://{env.HOSTNAME}/auth/v1/{PROVIDER}/callback")
 SCOPE_SEP = " "
+
+
+def _get_redirect_uri() -> schema.Url:
+    """Get redirect URI with runtime env access."""
+    from campus.common import env
+    return schema.Url(f"https://{env.HOSTNAME}/auth/v1/{PROVIDER}/callback")
 
 
 def get_proxy() -> "GoogleAuthProxy":
@@ -49,7 +54,7 @@ class GoogleAuthProxy(base.AuthProxy):
         self._oauth2 = webauth.oauth2.OAuth2AuthorizationCodeFlowScheme(
             provider=PROVIDER,
             client_id=self._CLIENT_ID,
-            redirect_uri=REDIRECT_URI,
+            redirect_uri=_get_redirect_uri(),
             authorization_url=schema.Url(
                 "https://accounts.google.com/o/oauth2/v2/auth"
             ),
@@ -95,7 +100,7 @@ class GoogleAuthProxy(base.AuthProxy):
         """Redirect to Google OAuth2 authorization endpoint."""
         authsession = self.init_authsession(
             expiry_seconds=campus.config.DEFAULT_OAUTH_EXPIRY_MINUTES * 60,
-            redirect_uri=REDIRECT_URI,
+            redirect_uri=_get_redirect_uri(),
             scopes=self._oauth2.scopes,
             target=target
         )
@@ -134,6 +139,8 @@ class GoogleAuthProxy(base.AuthProxy):
         Returns:
             Updated UserCredentials instance
         """
+        # Import env at runtime for WORKSPACE_DOMAIN access
+        from campus.common import env
         authsession = self.get_authsession()
         self.validate_authsession(authsession, state)
         # Retrieve access token from Google

--- a/campus/common/utils/url.py
+++ b/campus/common/utils/url.py
@@ -3,10 +3,14 @@
 This module provides utility functions for URL manipulation and validation.
 """
 
+from typing import TYPE_CHECKING
 import typing
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 import flask
+
+if TYPE_CHECKING:
+    from campus.common import env
 
 
 def create_url(

--- a/campus/common/utils/url.py
+++ b/campus/common/utils/url.py
@@ -3,14 +3,10 @@
 This module provides utility functions for URL manipulation and validation.
 """
 
-from typing import TYPE_CHECKING
 import typing
 from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 import flask
-
-if TYPE_CHECKING:
-    from campus.common import env
 
 
 def create_url(

--- a/campus/common/utils/url.py
+++ b/campus/common/utils/url.py
@@ -8,8 +8,6 @@ from urllib.parse import urlparse, urlunparse, urlencode, parse_qs
 
 import flask
 
-from campus.common import env
-
 
 def create_url(
         *,
@@ -42,6 +40,9 @@ def full_url_for(
         **kwargs: Additional arguments to build the URL. Passed to
                   `url_for`.
     """
+    # Import env only at runtime to avoid capturing module instead of
+    # EnvironmentProxy
+    from campus.common import env
     hostname = hostname or env.HOSTNAME
     # Validate that endpoint does not contain scheme or domain
     if urlparse(endpoint).scheme or urlparse(endpoint).netloc:


### PR DESCRIPTION
Fixes an issue where campus.common.env attributes were not accessible when imported at module level.

The campus.common.env module replaces itself with an EnvironmentProxy instance at import time. However, modules that import env at module level capture a reference to the original module object before the replacement occurs.

This caused errors like:
AttributeError: module 'campus.common.env' has no attribute 'HOSTNAME'

Changed files:
- campus/common/utils/url.py
- campus/auth/oauth_proxy/campus/proxy.py
- campus/auth/oauth_proxy/google/proxy.py
- campus/auth/oauth_proxy/discord/proxy.py
- campus/auth/oauth_proxy/github/proxy.py

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>