### PR TITLE
fix: move user auto-provisioning to Campus OAuth flow

### DIFF
--- a/campus/auth/oauth_proxy/google/proxy.py
+++ b/campus/auth/oauth_proxy/google/proxy.py
@@ -166,11 +166,6 @@ class GoogleAuthProxy(base.AuthProxy):
                 domain=user_email.domain
             )
         user_id = schema.UserID(userinfo["email"])
-        # Ensure user exists (auto-provision)
-        resources.user.get_or_create(
-            email=user_email,
-            name=userinfo.get("name", "")
-        )
         # Store/update token
         credentials = resources.credentials[PROVIDER][user_id].update(
             client_id=self._CLIENT_ID,

--- a/campus/auth/provider.py
+++ b/campus/auth/provider.py
@@ -310,10 +310,11 @@ def verify_login_and_redirect(
             domain=user.domain
         )
 
-    # Verify user has valid Google credential
+    # Verify user has valid Google credential and get userinfo for provisioning
     google_client_id = resources.vault["google"]["CLIENT_ID"]
+    google_cred = None
     try:
-        google_cred_resource[user].get(google_client_id)
+        google_cred = google_cred_resource[user].get(google_client_id)
     except api_errors.NotFoundError:
         # User does not have a valid Google credential/sign-in
         # TODO: Display error page
@@ -321,6 +322,18 @@ def verify_login_and_redirect(
             "No valid Google credential found for user",
             user_id=user
         ) from None
+
+    # Get userinfo from Google to provision user record
+    # Import at runtime to avoid circular dependency - type: ignore for pyright
+    from campus.auth.oauth_proxy.google import get_proxy  # type: ignore
+    proxy = get_proxy()
+    userinfo = proxy._oauth2.get_user_info(google_cred.token.access_token)  # type: ignore[arg-type]
+
+    # Provision user record (auto-create if not exists)
+    resources.user.get_or_create(
+        email=schema.Email(user),
+        name=userinfo.get("name", "")
+    )
 
     # Generate authorization code AFTER successful Google authentication
     authorization_code = secret.generate_authorization_code()

--- a/campus/auth/provider.py
+++ b/campus/auth/provider.py
@@ -33,6 +33,8 @@ Legend:
     Google's token endpoint for user profile.
 """
 
+import logging
+
 import flask
 import werkzeug
 
@@ -43,6 +45,8 @@ from campus.common.errors import api_errors, auth_errors, token_errors
 from campus.common.utils import secret, url, utc_time
 
 from . import resources
+
+logger = logging.getLogger(__name__)
 
 PROVIDER = "campus"
 INVALIDATED = "INVALIDATED"  # Marker for used authorization codes
@@ -330,9 +334,17 @@ def verify_login_and_redirect(
     userinfo = proxy._oauth2.get_user_info(google_cred.token.access_token)  # type: ignore[arg-type]
 
     # Provision user record (auto-create if not exists)
+    user_name = userinfo.get("name", "")
+    if not user_name:
+        # Fallback to email localpart if name is empty
+        user_name = str(user).split("@")[0]
+        logger.warning(
+            "Google userinfo missing 'name' field for user %s, using email localpart '%s' as fallback",
+            user, user_name
+        )
     resources.user.get_or_create(
         email=schema.Email(user),
-        name=userinfo.get("name", "")
+        name=user_name
     )
 
     # Generate authorization code AFTER successful Google authentication

--- a/campus/auth/provider.py
+++ b/campus/auth/provider.py
@@ -331,7 +331,22 @@ def verify_login_and_redirect(
     # Import at runtime to avoid circular dependency - type: ignore for pyright
     from campus.auth.oauth_proxy.google import get_proxy  # type: ignore
     proxy = get_proxy()
-    userinfo = proxy._oauth2.get_user_info(google_cred.token.access_token)  # type: ignore[arg-type]
+
+    # Refresh Google token if expired before fetching userinfo
+    token = google_cred.token
+    if token.is_expired():
+        token = proxy._oauth2.refresh_token(
+            token,
+            client_id=proxy._CLIENT_ID,
+            client_secret=proxy._CLIENT_SECRET
+        )
+        # Update the stored credential with refreshed token
+        resources.credentials["google"][user].update(
+            client_id=proxy._CLIENT_ID,
+            token=token,
+        )
+
+    userinfo = proxy._oauth2.get_user_info(token.access_token)  # type: ignore[arg-type]
 
     # Provision user record (auto-create if not exists)
     user_name = userinfo.get("name", "")


### PR DESCRIPTION
This fixes issue #379 by properly architecting where user auto-provisioning happens:

- Campus Auth: Now auto-provisions users after successful Google authentication and domain validation. This is the correct entry point for new users into the Campus ecosystem.

- Google OAuth proxy: Removed auto-provisioning. Third-party providers should only store credentials for existing users, not create new user records.

The fix resolves the NotFoundError when campus-profile users sign in, as the user record is now created during the Campus OAuth flow rather than being skipped entirely.

Closes #379 