### PR TITLE
fix: properly deserialize DateTime fields in OAuthToken.from_storage()

### DIFF
--- a/campus/model/credentials.py
+++ b/campus/model/credentials.py
@@ -71,6 +71,26 @@ class OAuthToken(Model):
             if scope not in requested_scopes
         ]
 
+    @classmethod
+    def from_storage(cls, record: dict) -> "OAuthToken":
+        """Create OAuthToken from storage record, properly deserializing DateTime fields.
+
+        Args:
+            record: Storage record dictionary
+
+        Returns:
+            OAuthToken instance with DateTime fields properly deserialized
+        """
+        # Convert string datetime values to schema.DateTime objects
+        processed = record.copy()
+        if "expires_at" in processed and isinstance(processed["expires_at"], str):
+            processed["expires_at"] = schema.DateTime(processed["expires_at"])
+        if "refresh_token_expires_at" in processed and isinstance(processed["refresh_token_expires_at"], str):
+            processed["refresh_token_expires_at"] = schema.DateTime(processed["refresh_token_expires_at"])
+        if "created_at" in processed and isinstance(processed["created_at"], str):
+            processed["created_at"] = schema.DateTime(processed["created_at"])
+        return super().from_storage(processed)
+
 
 @dataclass(eq=False, kw_only=True)
 class UserCredentials(Model):


### PR DESCRIPTION
The base Model.from_storage() doesn't handle DateTime deserialization, so string values from the database remain plain str instead of schema.DateTime. This caused AttributeError when calling is_expired() because str doesn't have to_datetime().

Override from_storage() to convert datetime string fields to schema.DateTime objects.