### PR TITLE
Fix OAuth token conflict - remove duplicate token creation

### DIFF
--- a/campus/auth/provider.py
+++ b/campus/auth/provider.py
@@ -259,22 +259,33 @@ def token(
     user_credentials_resource = (
         campus_cred_resource[authsession.user_id]
     )
-    credentials = user_credentials_resource.get(authsession.client_id)
-    # Create token if not existing
-    if credentials.token and not credentials.token.is_expired():
+
+    # Try to get existing credentials
+    credentials = None
+    try:
+        credentials = user_credentials_resource.get(authsession.client_id)
+    except api_errors.NotFoundError:
+        pass
+
+    # Use existing token if available and not expired, otherwise create new
+    if (
+        credentials is not None
+        and credentials.token is not None
+        and not credentials.token.is_expired()
+    ):
         token = credentials.token
     else:
         token = user_credentials_resource.new(
-            client_id=client_id,
-            # TODO: user consent screen for scope grant
+            client_id=authsession.client_id,
             scopes=authsession.scopes,
             expiry_seconds=(
                 campus.config.DEFAULT_TOKEN_EXPIRY_DAYS
                 * utc_time.DAY_SECONDS
             ),
         )
+        # Update credentials with the new token
         user_credentials_resource.update(
-            client_id=credentials.client_id,
+            client_id=authsession.client_id,
             token=token
         )
     return token.to_resource(), 200
@@ -376,16 +387,8 @@ def verify_login_and_redirect(
         authorization_code=authorization_code
     )
 
-    # Issue Campus token and update credentials
-    # Token will be exchanged by app with auth code thru /token endpoint
-    resources.credentials[PROVIDER][user].new(
-        client_id=authsession.client_id,
-        scopes=authsession.scopes,
-        expiry_seconds=(
-            campus.config.DEFAULT_TOKEN_EXPIRY_DAYS
-            * utc_time.DAY_SECONDS
-        ),
-    )
+    # NOTE: Token creation is now handled by /token endpoint
+    # This endpoint only creates the authorization code for the app to exchange
     
     # Redirect to app callback (redirect_uri, not final target)
     assert authsession.state and authsession.authorization_code


### PR DESCRIPTION
## Summary

Fixes the OAuth sign-in flow that was creating duplicate campus tokens, causing PostgreSQL unique constraint violations.

## Problem

The `verify_login_and_redirect` endpoint was creating campus tokens, and then the `/token` endpoint was also creating tokens. This resulted in duplicate `token_id` values, violating the PostgreSQL unique constraint.

## Solution

- **Remove token creation from `verify_login_and_redirect`**: This endpoint now ONLY creates authorization codes for apps to exchange
- **Fix `/token` endpoint to handle missing credentials**: Previously, if credentials didn't exist, it would raise `NotFoundError`. Now it creates new credentials properly.

## Changes

- Removed `resources.credentials[PROVIDER][user].new()` call from `verify_login_and_redirect`
- Added try/except in `/token` to handle `NotFoundError` when credentials don't exist
- Token creation now happens ONLY in the `/token` endpoint

## Testing

1. Sign in to campus-profile as a new user
2. Verify that token is created successfully
3. Verify that subsequent sign-ins work correctly

Fixes #416

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>