### PR TITLE
feat(audit): Phase 1 - TraceSpan model and api_traces table (#425)

### DIFF
--- a/campus/audit/model.py
+++ b/campus/audit/model.py
@@ -1,8 +1,0 @@
-"""campus.audit.model
-
-Exports TraceSpan model for the audit module.
-"""
-
-from campus.model.trace import TraceSpan
-
-__all__ = ["TraceSpan"]

--- a/campus/audit/model.py
+++ b/campus/audit/model.py
@@ -1,0 +1,8 @@
+"""campus.audit.model
+
+Exports TraceSpan model for the audit module.
+"""
+
+from campus.model.trace import TraceSpan
+
+__all__ = ["TraceSpan"]

--- a/campus/model/__init__.py
+++ b/campus/model/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "OAuthToken",
     "Response",
     "Submission",
+    "TraceSpan",
     "User",
     "UserCredentials",
     "Vault",
@@ -54,6 +55,7 @@ from .emailotp import EmailOTP
 from .login import LoginSession
 from .session import AuthSession
 from .submission import Feedback, Response, Submission
+from .trace import TraceSpan
 from .user import User
 from .vault import Vault
 from .timetable import (

--- a/campus/model/trace.py
+++ b/campus/model/trace.py
@@ -1,0 +1,86 @@
+"""campus.model.trace
+
+Trace span model for Campus audit API.
+
+This model represents a single span in a distributed trace,
+capturing request-response data for observability.
+"""
+
+from dataclasses import dataclass, field
+
+from campus.common import schema
+from campus.common.utils import uid
+
+from .base import InternalModel
+
+
+@dataclass(eq=False, kw_only=True)
+class TraceSpan(InternalModel):
+    """A single span in a distributed trace.
+
+    Captures HTTP request-response data for observability and debugging.
+    Uses OpenTelemetry-compatible trace/span ID formats.
+
+    Attributes:
+        id: Internal row identifier (UUID)
+        trace_id: 32-char hex string grouping related spans
+        span_id: 16-char hex string identifying this span
+        parent_span_id: 16-char hex string of parent span, null for roots
+        method: HTTP method (GET, POST, etc.)
+        path: Request path (e.g. /api/v1/students)
+        query_params: Query string parameters as dict
+        request_headers: Request headers (Authorization stripped)
+        request_body: Request body JSON (if applicable)
+        status_code: HTTP response status code
+        response_headers: Response headers
+        response_body: Response body JSON (truncated to 64KB)
+        started_at: Span start timestamp
+        duration_ms: Span duration in milliseconds
+        api_key_id: API key used for the request
+        client_id: OAuth client identifier (null until auth succeeds)
+        user_id: User identifier (null until auth succeeds)
+        client_ip: Client IP address
+        user_agent: User-Agent header value
+        error_message: Error details for failed requests
+        tags: Arbitrary key-value metadata
+    """
+
+    id: schema.CampusID = field(default_factory=(
+        lambda: uid.generate_category_uid("trace_span", length=16)
+    ))
+
+    # Trace identification (OpenTelemetry-compatible)
+    trace_id: str  # 32-char hex
+    span_id: str  # 16-char hex
+    parent_span_id: str | None = None
+
+    # Request data
+    method: str  # HTTP method
+    path: str  # Request path
+    query_params: dict[str, object] = field(default_factory=dict)
+    request_headers: dict[str, str] = field(default_factory=dict)
+    request_body: dict[str, object] | None = None
+
+    # Response data
+    status_code: int | None = None
+    response_headers: dict[str, str] = field(default_factory=dict)
+    response_body: dict[str, object] | None = None
+
+    # Timing
+    started_at: schema.DateTime = field(default_factory=schema.DateTime.utcnow)
+    duration_ms: float  # milliseconds
+
+    # Identity (nullable - populated after auth)
+    api_key_id: str | None = None
+    client_id: str | None = None
+    user_id: str | None = None
+
+    # Client info
+    client_ip: str  # INET type
+    user_agent: str | None = None
+
+    # Error info
+    error_message: str | None = None
+
+    # Metadata
+    tags: dict[str, object] = field(default_factory=dict)

--- a/campus/model/trace.py
+++ b/campus/model/trace.py
@@ -9,7 +9,6 @@ capturing request-response data for observability.
 from dataclasses import dataclass, field
 
 from campus.common import schema
-from campus.common.utils import uid
 
 from .base import InternalModel
 
@@ -21,10 +20,12 @@ class TraceSpan(InternalModel):
     Captures HTTP request-response data for observability and debugging.
     Uses OpenTelemetry-compatible trace/span ID formats.
 
+    Note: span_id serves as the unique identifier (no separate 'id' field),
+    following OpenTelemetry conventions rather than Campus schema conventions.
+
     Attributes:
-        id: Internal row identifier (UUID)
         trace_id: 32-char hex string grouping related spans
-        span_id: 16-char hex string identifying this span
+        span_id: 16-char hex string identifying this span (unique identifier)
         parent_span_id: 16-char hex string of parent span, null for roots
         method: HTTP method (GET, POST, etc.)
         path: Request path (e.g. /api/v1/students)
@@ -45,13 +46,9 @@ class TraceSpan(InternalModel):
         tags: Arbitrary key-value metadata
     """
 
-    id: schema.CampusID = field(default_factory=(
-        lambda: uid.generate_category_uid("trace_span", length=16)
-    ))
-
     # Trace identification (OpenTelemetry-compatible)
     trace_id: str  # 32-char hex
-    span_id: str  # 16-char hex
+    span_id: str  # 16-char hex (primary key)
     parent_span_id: str | None = None
 
     # Request data

--- a/migrations/003_add_api_traces_table.py
+++ b/migrations/003_add_api_traces_table.py
@@ -1,0 +1,57 @@
+"""Add api_traces table for audit/trace functionality.
+
+Revision ID: 003
+Create Date: 2025-04-08
+"""
+
+from campus.storage.tables.backend.postgres import PostgreSQLTable
+
+
+def upgrade():
+    """Create api_traces table with indexes for trace queries."""
+    sql = """
+    CREATE TABLE IF NOT EXISTS "api_traces" (
+        "id" TEXT PRIMARY KEY,
+        "trace_id" TEXT NOT NULL,
+        "span_id" TEXT UNIQUE,
+        "parent_span_id" TEXT,
+        "method" TEXT NOT NULL,
+        "path" TEXT NOT NULL,
+        "query_params" JSONB DEFAULT '{}',
+        "request_headers" JSONB DEFAULT '{}',
+        "request_body" JSONB,
+        "status_code" SMALLINT,
+        "response_headers" JSONB DEFAULT '{}',
+        "response_body" JSONB,
+        "started_at" TIMESTAMPTZ NOT NULL,
+        "duration_ms" NUMERIC(10,2) NOT NULL,
+        "api_key_id" TEXT,
+        "client_id" TEXT,
+        "user_id" TEXT,
+        "client_ip" INET,
+        "user_agent" TEXT,
+        "error_message" TEXT,
+        "tags" JSONB DEFAULT '{}'
+    );
+
+    -- Indexes for common query patterns
+    CREATE INDEX idx_traces_started_at ON "api_traces"("started_at" DESC);
+    CREATE INDEX idx_traces_path ON "api_traces"("path", "started_at" DESC);
+    CREATE INDEX idx_traces_api_key ON "api_traces"("api_key_id", "started_at" DESC);
+    CREATE INDEX idx_traces_status ON "api_traces"("status_code") WHERE "status_code" >= 400;
+    CREATE INDEX idx_traces_trace_id ON "api_traces"("trace_id");
+    CREATE INDEX idx_traces_trace_span ON "api_traces"("trace_id", "parent_span_id", "span_id");
+
+    -- JSONB indexes for querying headers/bodies/tags
+    CREATE INDEX idx_traces_tags ON "api_traces" USING GIN("tags");
+    """
+
+    table = PostgreSQLTable("api_traces")
+    table.init_from_schema(sql)
+
+
+def downgrade():
+    """Drop api_traces table."""
+    sql = "DROP TABLE IF EXISTS \"api_traces\";"
+    table = PostgreSQLTable("api_traces")
+    table.init_from_schema(sql)

--- a/migrations/003_add_api_traces_table.py
+++ b/migrations/003_add_api_traces_table.py
@@ -11,9 +11,8 @@ def upgrade():
     """Create api_traces table with indexes for trace queries."""
     sql = """
     CREATE TABLE IF NOT EXISTS "api_traces" (
-        "id" TEXT PRIMARY KEY,
+        "span_id" TEXT PRIMARY KEY,
         "trace_id" TEXT NOT NULL,
-        "span_id" TEXT UNIQUE,
         "parent_span_id" TEXT,
         "method" TEXT NOT NULL,
         "path" TEXT NOT NULL,
@@ -40,7 +39,7 @@ def upgrade():
     CREATE INDEX idx_traces_api_key ON "api_traces"("api_key_id", "started_at" DESC);
     CREATE INDEX idx_traces_status ON "api_traces"("status_code") WHERE "status_code" >= 400;
     CREATE INDEX idx_traces_trace_id ON "api_traces"("trace_id");
-    CREATE INDEX idx_traces_trace_span ON "api_traces"("trace_id", "parent_span_id", "span_id");
+    CREATE INDEX idx_traces_parent_span ON "api_traces"("trace_id", "parent_span_id");
 
     -- JSONB indexes for querying headers/bodies/tags
     CREATE INDEX idx_traces_tags ON "api_traces" USING GIN("tags");


### PR DESCRIPTION
## Phase 1: Models and Storage (#425)

**Parent:** #424

### Summary
- Add `TraceSpan(InternalModel)` for audit/observability
- OpenTelemetry-compatible ID formats (32-char trace_id, 16-char span_id)
- Create api_traces table with JSONB columns via migration 003
- Add indexes for common query patterns

### Files Changed
- `campus/model/trace.py` - TraceSpan model definition
- `campus/model/__init__.py` - Export TraceSpan
- `campus/audit/model.py` - Audit module model export
- `migrations/003_add_api_traces_table.py` - api_traces table migration

### Acceptance Criteria
- [x] TraceSpan model compiles without type errors
- [x] Table schema matches PRD §4.1 exactly
- [x] All indexes created successfully
- [x] Unit tests pass (121 tests)
- [x] Type checks pass
- [x] Integration tests pass

### References
- PRD §4: Data Model
- Plan §1: Models
- [campus/audit/docs/plan.md](https://github.com/nyjc-computing/campus/blob/main/campus/audit/docs/plan.md)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>