### PR TITLE
feat(audit): Phase 4 - Tracing middleware structure (stub) (#428)

### DIFF
--- a/campus/audit/middleware/__init__.py
+++ b/campus/audit/middleware/__init__.py
@@ -1,0 +1,50 @@
+"""campus.audit.middleware
+
+Request tracing middleware for Campus audit API.
+
+This module provides automatic span capture for HTTP requests flowing
+through campus.auth and campus.api deployments.
+"""
+
+__all__ = ["init_app"]
+
+import flask
+
+
+def init_app(app: flask.Flask) -> None:
+    """Initialize tracing middleware for the Flask app.
+
+    Registers before_request and after_request hooks to capture
+    request-response data as spans.
+
+    Note: Should only be called for campus.auth and campus.api deployments,
+    not for campus.audit (to avoid infinite recursion).
+
+    Args:
+        app: The Flask application to instrument.
+    """
+    from . import tracing
+
+    @app.before_request
+    def start_span():
+        """Start a root span for each incoming request.
+
+        Generates or reuses trace_id from X-Request-ID header.
+        Stores timing and identifier data in flask.g for use in after_request.
+        """
+        tracing.start_span()
+
+    @app.after_request
+    def end_span(response):
+        """Complete the span and send to audit service.
+
+        Builds TraceSpan from request/response data and ingests asynchronously.
+        Echoes trace_id in response headers for correlation.
+
+        Args:
+            response: The Flask response object.
+
+        Returns:
+            The response with X-Request-ID header added.
+        """
+        return tracing.end_span(response)

--- a/campus/audit/middleware/tracing.py
+++ b/campus/audit/middleware/tracing.py
@@ -1,0 +1,89 @@
+"""campus.audit.middleware.tracing
+
+Tracing middleware implementation for capturing HTTP request-response spans.
+"""
+
+import flask
+
+from campus.common import schema
+from campus.common.utils import uid
+
+
+def start_span() -> None:
+    """Start a root span for the incoming request.
+
+    - Generates or reuses trace_id from X-Request-ID header
+    - Generates span_id for this request
+    - Stores timing data in flask.g
+
+    Stores in flask.g:
+        - trace_id: 32-char hex trace identifier
+        - span_id: 16-char hex span identifier
+        - trace_start: timestamp for duration calculation
+    """
+    # TODO: Implement span start logic
+    # - Check X-Request-ID header, generate if missing
+    # - Generate span_id
+    # - Store timing start
+    pass
+
+
+def end_span(response: flask.Response) -> flask.Response:
+    """Complete the span and ingest to audit service.
+
+    - Builds TraceSpan from flask.request, flask.g, and response
+    - Ingests asynchronously to avoid blocking
+    - Echoes trace_id in response headers
+
+    Args:
+        response: The Flask response object
+
+    Returns:
+        Response with X-Request-ID header added
+    """
+    # TODO: Implement span completion logic
+    # - Build TraceSpan from context
+    # - Ingest via HTTP to campus.audit
+    # - Add X-Request-ID header to response
+    return response
+
+
+def build_span_from_context(
+    trace_id: str,
+    span_id: str,
+    response: flask.Response,
+    duration_ms: float,
+) -> dict:
+    """Build a span dict from request/response context.
+
+    Args:
+        trace_id: The trace identifier
+        span_id: The span identifier
+        response: The Flask response object
+        duration_ms: Request duration in milliseconds
+
+    Returns:
+        Dictionary representation of the span for ingestion.
+    """
+    # TODO: Extract data from flask.request and response
+    # - Strip Authorization header
+    # - Get request body (if applicable)
+    # - Get response body (truncated to 64KB)
+    # - Handle client_id/user_id from flask.g if available
+    return {}
+
+
+def ingest_span(span: dict) -> None:
+    """Send span to audit service via HTTP.
+
+    Uses campus.common.http.DefaultClient to POST to /audit/v1/traces.
+    Reads AUDIT_API_URL and AUDIT_API_KEY from environment.
+
+    Args:
+        span: Span data dictionary to ingest
+    """
+    # TODO: Implement HTTP ingestion
+    # - Get or create audit API client
+    # - POST to /audit/v1/traces
+    # - Handle failures gracefully
+    pass

--- a/campus/common/devops/deploy.py
+++ b/campus/common/devops/deploy.py
@@ -115,4 +115,11 @@ def create_app(*appmodules: AppModule) -> flask.Flask:
     for module in appmodules:
         module.init_app(app)
     campus.common.errors.init_app(app)
+
+    # Register tracing middleware for auth/api deployments
+    # campus.audit handles ingestion but doesn't trace its own requests
+    if env.DEPLOY in ('campus.auth', 'campus.api'):
+        from campus.audit import middleware
+        middleware.init_app(app)
+
     return app

--- a/campus/common/utils/uid.py
+++ b/campus/common/utils/uid.py
@@ -49,3 +49,25 @@ def generate_user_uid(email: str) -> schema.UserID:
     """
     user_id, _ = email.split('@')
     return schema.UserID(user_id)
+
+
+def generate_trace_id() -> str:
+    """Generate a 32-char hex trace ID (OpenTelemetry-compatible).
+
+    OpenTelemetry trace IDs are 128-bit values represented as 32 lowercase hex characters.
+
+    Returns:
+        A 32-character hexadecimal string.
+    """
+    return uuid.uuid4().hex + uuid.uuid4().hex[:16]
+
+
+def generate_span_id() -> str:
+    """Generate a 16-char hex span ID (OpenTelemetry-compatible).
+
+    OpenTelemetry span IDs are 64-bit values represented as 16 lowercase hex characters.
+
+    Returns:
+        A 16-character hexadecimal string.
+    """
+    return uuid.uuid4().hex[:16]


### PR DESCRIPTION
## Phase 4: Tracing Middleware (#428)

**Parent:** #424

### Summary
- Add `generate_trace_id()` and `generate_span_id()` to `campus.common.utils.uid`
- Create `campus.audit.middleware` module with tracing hooks
- Register middleware in `devops.deploy.create_app()` for auth/api only

### Architecture Decisions

**Conditional Registration:**
- Middleware registered for `campus.auth` and `campus.api` deployments
- **Skipped** for `campus.audit` to avoid infinite recursion
- No path-based filtering needed - deployment mode is the boundary

**Ingestion Approach:**
- HTTP-based ingestion to separate `campus.audit` deployment
- Enables write coalescing at the audit service level
- Follows Campus pattern of separate deployments per service

### Files Changed
- `campus/common/utils/uid.py` - Add trace/span ID generation functions
- `campus/audit/middleware/__init__.py` - Middleware initialization
- `campus/audit/middleware/tracing.py` - Stub functions for span capture
- `campus/common/devops/deploy.py` - Register middleware for auth/api

### Stub Functions (Not Yet Implemented)
- `start_span()` - Generate/reuse trace_id, store timing in flask.g
- `end_span()` - Build span, ingest via HTTP, add X-Request-ID header
- `build_span_from_context()` - Extract request/response data
- `ingest_span()` - HTTP POST to `/audit/v1/traces`

### Acceptance Criteria
- [x] Middleware structure created
- [x] Registration in devops.deploy for auth/api only
- [x] Tests pass (unit + integration)
- [x] Type checks pass

### Next Steps
- Implement stub functions with actual span capture logic
- Add async ingestion to avoid blocking requests
- Handle Authorization header stripping

### References
- PRD §9.1: Middleware-Based Ingestion
- Plan §6: Middleware for Trace Capture
- [campus/audit/docs/plan.md](https://github.com/nyjc-computing/campus/blob/main/campus/audit/docs/plan.md)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>