### PR TITLE
Add query operators for storage filtering

### DIFF
--- a/campus/storage/__init__.py
+++ b/campus/storage/__init__.py
@@ -24,6 +24,12 @@ __all__ = [
     "purge_buckets",
     "purge_collections",
     "purge_tables",
+    # Query operators
+    "gt",
+    "gte",
+    "lt",
+    "lte",
+    "is_operator",
 ]
 
 from campus.common import devops
@@ -39,6 +45,7 @@ from .errors import (
     NotFoundError,
     NoChangesAppliedError
 )
+from .query import gt, gte, lt, lte, is_operator
 
 
 def get_table(name: str) -> TableInterface:

--- a/campus/storage/documents/interface.py
+++ b/campus/storage/documents/interface.py
@@ -29,8 +29,43 @@ class CollectionInterface(ABC):
         ...
 
     @abstractmethod
-    def get_matching(self, query: dict) -> list[dict]:
-        """Retrieve documents matching a query."""
+    def get_matching(
+        self,
+        query: dict,
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> list[dict]:
+        """Retrieve documents matching a query.
+
+        Args:
+            query: Dictionary of field to value mappings for filtering.
+                   Values can be exact matches or Operator instances for
+                   comparison queries (gt, gte, lt, lte).
+                   Multiple fields are treated as implicit AND (all conditions must match).
+            order_by: Field name to sort by. If None, results are unordered.
+            ascending: Sort direction. True for ascending, False for descending.
+            limit: Maximum number of documents to return. If None, all matching documents are returned.
+            offset: Number of documents to skip before returning results.
+
+        Returns:
+            List of matching documents as dictionaries.
+
+        Example:
+            # Simple exact match
+            get_matching({"user_id": "user_123"})
+
+            # With operators
+            get_matching({"duration_ms": gt(1000)})
+
+            # Multiple fields (implicit AND)
+            get_matching({"user_id": "user_123", "status": "active"})
+
+            # With sorting and pagination
+            get_matching({"status": "active"}, order_by="created_at", ascending=False, limit=10, offset=0)
+        """
         ...
 
     @abstractmethod

--- a/campus/storage/query.py
+++ b/campus/storage/query.py
@@ -1,0 +1,75 @@
+"""campus.storage.query
+
+This module provides query operators for storage filtering.
+
+These operators enable more expressive queries while maintaining backward
+compatibility with simple exact-match queries.
+
+Example:
+    from campus.storage.query import gt, gte, lt, lte
+
+    # Simple exact match (backward compatible)
+    storage.get_matching({"user_id": "user_123"})
+
+    # With operators
+    storage.get_matching({"duration_ms": gt(1000)})
+    storage.get_matching({"started_at": gte("2024-01-01")})
+    storage.get_matching({"status_code": lt(500)})
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Operator:
+    """Base class for query operators.
+
+    Operators are immutable value objects that represent comparison
+    operations in queries.
+    """
+    value: Any
+
+
+class gt(Operator):
+    """Greater than comparison.
+
+    Example:
+        {"duration_ms": gt(1000)}  # duration_ms > 1000
+    """
+
+
+class gte(Operator):
+    """Greater than or equal comparison.
+
+    Example:
+        {"started_at": gte("2024-01-01")}  # started_at >= "2024-01-01"
+    """
+
+
+class lt(Operator):
+    """Less than comparison.
+
+    Example:
+        {"timeout": lt(5000)}  # timeout < 5000
+    """
+
+
+class lte(Operator):
+    """Less than or equal comparison.
+
+    Example:
+        {"retries": lte(3)}  # retries <= 3
+    """
+
+
+def is_operator(value: Any) -> bool:
+    """Check if a value is a query operator.
+
+    Args:
+        value: The value to check
+
+    Returns:
+        True if the value is an Operator instance, False otherwise
+    """
+    return isinstance(value, Operator)

--- a/campus/storage/tables/interface.py
+++ b/campus/storage/tables/interface.py
@@ -39,8 +39,43 @@ class TableInterface(ABC):
         ...
 
     @abstractmethod
-    def get_matching(self, query: dict) -> list[dict]:
-        """Retrieve rows matching a query."""
+    def get_matching(
+        self,
+        query: dict,
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> list[dict]:
+        """Retrieve rows matching a query.
+
+        Args:
+            query: Dictionary of field to value mappings for filtering.
+                   Values can be exact matches or Operator instances for
+                   comparison queries (gt, gte, lt, lte).
+                   Multiple fields are treated as implicit AND (all conditions must match).
+            order_by: Field name to sort by. If None, results are unordered.
+            ascending: Sort direction. True for ascending, False for descending.
+            limit: Maximum number of rows to return. If None, all matching rows are returned.
+            offset: Number of rows to skip before returning results.
+
+        Returns:
+            List of matching rows as dictionaries.
+
+        Example:
+            # Simple exact match
+            get_matching({"user_id": "user_123"})
+
+            # With operators
+            get_matching({"duration_ms": gt(1000)})
+
+            # Multiple fields (implicit AND)
+            get_matching({"user_id": "user_123", "status": "active"})
+
+            # With sorting and pagination
+            get_matching({"status": "active"}, order_by="created_at", ascending=False, limit=10, offset=0)
+        """
         ...
 
     @abstractmethod

--- a/tests/unit/storage/test_query_operators.py
+++ b/tests/unit/storage/test_query_operators.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Test query operators for storage filtering."""
+
+import unittest
+import dataclasses
+
+
+class TestQueryOperators(unittest.TestCase):
+    """Test query operator classes."""
+
+    def test_operator_is_frozen_dataclass(self):
+        """Operator instances should be immutable."""
+        from campus.storage.query import gt
+
+        op = gt(100)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            op.value = 200
+
+    def test_gt_operator(self):
+        """gt operator stores value correctly."""
+        from campus.storage.query import gt, is_operator
+
+        op = gt(100)
+        self.assertEqual(op.value, 100)
+        self.assertTrue(is_operator(op))
+
+    def test_gte_operator(self):
+        """gte operator stores value correctly."""
+        from campus.storage.query import gte, is_operator
+
+        op = gte("2024-01-01")
+        self.assertEqual(op.value, "2024-01-01")
+        self.assertTrue(is_operator(op))
+
+    def test_lt_operator(self):
+        """lt operator stores value correctly."""
+        from campus.storage.query import lt, is_operator
+
+        op = lt(5000)
+        self.assertEqual(op.value, 5000)
+        self.assertTrue(is_operator(op))
+
+    def test_lte_operator(self):
+        """lte operator stores value correctly."""
+        from campus.storage.query import lte, is_operator
+
+        op = lte(3)
+        self.assertEqual(op.value, 3)
+        self.assertTrue(is_operator(op))
+
+    def test_is_operator_returns_true_for_operators(self):
+        """is_operator returns True for all operator types."""
+        from campus.storage.query import gt, gte, lt, lte, is_operator
+
+        self.assertTrue(is_operator(gt(100)))
+        self.assertTrue(is_operator(gte(100)))
+        self.assertTrue(is_operator(lt(100)))
+        self.assertTrue(is_operator(lte(100)))
+
+    def test_is_operator_returns_false_for_non_operators(self):
+        """is_operator returns False for regular values."""
+        from campus.storage.query import is_operator
+
+        self.assertFalse(is_operator(100))
+        self.assertFalse(is_operator("string"))
+        self.assertFalse(is_operator(None))
+        self.assertFalse(is_operator({"key": "value"}))
+        self.assertFalse(is_operator([1, 2, 3]))
+
+    def test_operators_are_hashable(self):
+        """Operators should be hashable for use in sets/dicts."""
+        from campus.storage.query import gt
+
+        op1 = gt(100)
+        op2 = gt(100)
+        op3 = gt(200)
+
+        # Same values should be equal
+        self.assertEqual(op1, op2)
+        self.assertNotEqual(op1, op3)
+
+        # Should be hashable
+        op_set = {op1, op2, op3}
+        self.assertEqual(len(op_set), 2)  # op1 and op2 are equal
+
+    def test_operators_with_different_types(self):
+        """Operators should work with various value types."""
+        from campus.storage.query import gt, lt, gte, lte, is_operator
+        from datetime import datetime
+
+        # Integer
+        self.assertTrue(is_operator(gt(100)))
+
+        # Float
+        self.assertTrue(is_operator(lt(3.14)))
+
+        # String
+        self.assertTrue(is_operator(gte("2024-01-01")))
+
+        # DateTime
+        dt = datetime(2024, 1, 1)
+        self.assertTrue(is_operator(lte(dt)))
+
+    def test_operator_type_checking(self):
+        """Operator instances are identified by their type."""
+        from campus.storage.query import gt, gte, lt, lte, is_operator, Operator
+
+        gt_op = gt(100)
+        gte_op = gte(100)
+        lt_op = lt(100)
+        lte_op = lte(100)
+
+        # All are operators
+        self.assertTrue(is_operator(gt_op))
+        self.assertTrue(is_operator(gte_op))
+        self.assertTrue(is_operator(lt_op))
+        self.assertTrue(is_operator(lte_op))
+
+        # Each is a different type
+        self.assertIsInstance(gt_op, gt)
+        self.assertIsInstance(gte_op, gte)
+        self.assertIsInstance(lt_op, lt)
+        self.assertIsInstance(lte_op, lte)
+
+        # All inherit from Operator
+        self.assertIsInstance(gt_op, Operator)
+        self.assertIsInstance(gte_op, Operator)
+        self.assertIsInstance(lt_op, Operator)
+        self.assertIsInstance(lte_op, Operator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add hybrid query operators (`gt`, `gte`, `lt`, `lte`) to enable more expressive storage queries while maintaining backward compatibility with exact-match queries.

## Changes

- **New file**: `campus/storage/query.py` - Defines operator base class and comparison operators
- **Updated**: `campus/storage/tables/interface.py` - Added `order_by`, `ascending`, `limit`, `offset` params to `get_matching()`
- **Updated**: `campus/storage/documents/interface.py` - Same `get_matching()` updates as tables
- **Updated**: `campus/storage/__init__.py` - Exports query operators (`gt`, `gte`, `lt`, `lte`, `is_operator`)
- **New file**: `tests/unit/storage/test_query_operators.py` - Unit tests for operator classes

## Usage Example

```python
from campus.storage import gt, gte, lt, lte

# Simple exact match (backward compatible)
storage.get_matching({"user_id": "user_123"})

# With operators
storage.get_matching({"duration_ms": gt(1000)})
storage.get_matching({"started_at": gte("2024-01-01")})

# Multiple fields (implicit AND)
storage.get_matching({"status": "active", "duration_ms": lt(5000)})

# With sorting and pagination
storage.get_matching({"status": "active"}, order_by="created_at", ascending=False, limit=10, offset=0)
```

## Test Plan

- [x] Unit tests for operator classes (passing)
- [ ] Backend implementations (PostgreSQL, MongoDB, Memory, SQLite) - separate PRs
- [ ] Integration tests with real backends

## Related Issues

This is part 1 of extending campus.storage query capabilities. Backend implementations will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)