### PR TITLE
feat(storage): implement query operators for all backends

### DIFF
--- a/campus/storage/documents/backend/memory.py
+++ b/campus/storage/documents/backend/memory.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List
 from campus.common import devops
 from campus.model import Model
 from campus.storage.documents.interface import CollectionInterface, PK
+from campus.storage.query import gt, gte, is_operator, lt, lte
 
 
 class MemoryCollection(CollectionInterface):
@@ -67,27 +68,81 @@ class MemoryCollection(CollectionInterface):
         collection = self._get_collection()
         return collection.get(doc_id)
 
-    def get_matching(self, query: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Retrieve documents matching a query."""
+    def get_matching(
+        self,
+        query: Dict[str, Any],
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Retrieve documents matching a query.
+
+        Supports exact matches, comparison operators (gt, gte, lt, lte),
+        sorting, and pagination.
+        """
         collection = self._get_collection()
 
         if not query:
             # Return all documents if no query
-            return list(collection.values())
+            matching_docs = list(collection.values())
+        else:
+            # Filter documents based on query
+            matching_docs = []
+            for doc in collection.values():
+                if self._matches_query(doc, query):
+                    matching_docs.append(doc)
 
-        # Simple query handling - exact matches only for this implementation
-        matching_docs = []
-        for doc in collection.values():
-            if self._matches_query(doc, query):
-                matching_docs.append(doc)
+        # Sort if order_by is specified
+        if order_by is not None:
+            reverse = not ascending
+            matching_docs.sort(key=lambda d: d.get(order_by), reverse=reverse)
+
+        # Apply offset
+        if offset > 0:
+            matching_docs = matching_docs[offset:]
+
+        # Apply limit
+        if limit is not None:
+            matching_docs = matching_docs[:limit]
 
         return matching_docs
 
     def _matches_query(self, doc: Dict[str, Any], query: Dict[str, Any]) -> bool:
-        """Check if a document matches a query."""
+        """Check if a document matches a query.
+
+        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        """
         for key, value in query.items():
-            if key not in doc or doc[key] != value:
+            if key not in doc:
                 return False
+
+            doc_value = doc[key]
+
+            if is_operator(value):
+                # Handle comparison operators
+                if isinstance(value, gt):
+                    if not (doc_value > value.value):
+                        return False
+                elif isinstance(value, gte):
+                    if not (doc_value >= value.value):
+                        return False
+                elif isinstance(value, lt):
+                    if not (doc_value < value.value):
+                        return False
+                elif isinstance(value, lte):
+                    if not (doc_value <= value.value):
+                        return False
+                else:
+                    # Unknown operator, fall back to exact match
+                    if doc_value != value.value:
+                        return False
+            else:
+                # Exact match
+                if doc_value != value:
+                    return False
+
         return True
 
     def insert_one(self, row: Dict[str, Any]):

--- a/campus/storage/documents/backend/memory.py
+++ b/campus/storage/documents/backend/memory.py
@@ -97,7 +97,9 @@ class MemoryCollection(CollectionInterface):
         # Sort if order_by is specified
         if order_by is not None:
             reverse = not ascending
-            matching_docs.sort(key=lambda d: d.get(order_by), reverse=reverse)
+            # Use tuple (has_key, value) so items without the key sort to the end
+            # Empty string is a safe default that works with most types
+            matching_docs.sort(key=lambda d: (order_by in d, d.get(order_by, "")), reverse=reverse)
 
         # Apply offset
         if offset > 0:

--- a/campus/storage/documents/backend/mongodb.py
+++ b/campus/storage/documents/backend/mongodb.py
@@ -39,6 +39,7 @@ from campus.storage.errors import (
     NotFoundError,
     StorageError
 )
+from campus.storage.query import gt, gte, is_operator, lt, lte
 
 MONGO_PK = "_id"  # MongoDB uses _id as the primary key
 
@@ -149,6 +150,36 @@ class MongoDBCollection(CollectionInterface):
         assert self._collection is not None
         return self._collection
 
+    @staticmethod
+    def _build_mongo_query(query: dict) -> dict:
+        """Build MongoDB query from query dictionary.
+
+        Translates Campus operators to MongoDB query syntax:
+        - gt(value) → {"field": {"$gt": value}}
+        - gte(value) → {"field": {"$gte": value}}
+        - lt(value) → {"field": {"$lt": value}}
+        - lte(value) → {"field": {"$lte": value}}
+        - exact match → {"field": value}
+        """
+        mongo_query = {}
+        for key, value in query.items():
+            if is_operator(value):
+                if isinstance(value, gt):
+                    mongo_query[key] = {"$gt": value.value}
+                elif isinstance(value, gte):
+                    mongo_query[key] = {"$gte": value.value}
+                elif isinstance(value, lt):
+                    mongo_query[key] = {"$lt": value.value}
+                elif isinstance(value, lte):
+                    mongo_query[key] = {"$lte": value.value}
+                else:
+                    # Unknown operator, fall back to exact match
+                    mongo_query[key] = value.value
+            else:
+                # Exact match
+                mongo_query[key] = value
+        return mongo_query
+
     def get_by_id(self, doc_id: str) -> dict:
         """Retrieve a document by its ID."""
         try:
@@ -161,11 +192,38 @@ class MongoDBCollection(CollectionInterface):
             return MongoRecord.from_mongo(mongo_doc).to_record()
         return {}
 
-    def get_matching(self, query: dict) -> list[dict]:
-        """Retrieve documents matching a query."""
+    def get_matching(
+        self,
+        query: dict,
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> list[dict]:
+        """Retrieve documents matching a query.
+
+        Supports exact matches, comparison operators (gt, gte, lt, lte),
+        sorting, and pagination.
+        """
         assert 'id' not in query, "Matching by 'id' is not allowed"
         try:
-            cursor = self.collection.find(query)
+            mongo_query = self._build_mongo_query(query)
+            cursor = self.collection.find(mongo_query)
+
+            # Add sorting if specified
+            if order_by is not None:
+                direction = 1 if ascending else -1
+                cursor = cursor.sort(order_by, direction)
+
+            # Add offset if specified
+            if offset > 0:
+                cursor = cursor.skip(offset)
+
+            # Add limit if specified
+            if limit is not None:
+                cursor = cursor.limit(limit)
+
         except Exception as e:
             raise MongoCollectionError(
                 f"Failed to retrieve documents matching query: {e}"
@@ -222,8 +280,9 @@ class MongoDBCollection(CollectionInterface):
         if not update:
             return
         try:
+            mongo_query = self._build_mongo_query(query)
             result = self.collection.update_many(
-                query,
+                mongo_query,
                 {
                     "$set": {
                         k: v for k, v in update.items() if v is not None
@@ -255,7 +314,8 @@ class MongoDBCollection(CollectionInterface):
         """Delete documents matching a query in the collection."""
         assert 'id' not in query, "Matching by 'id' is not allowed"
         try:
-            result = self.collection.delete_many(query)
+            mongo_query = self._build_mongo_query(query)
+            result = self.collection.delete_many(mongo_query)
         except Exception as e:
             raise MongoCollectionError(
                 f"Failed to delete documents matching query: {e}"

--- a/campus/storage/tables/backend/postgres.py
+++ b/campus/storage/tables/backend/postgres.py
@@ -33,6 +33,7 @@ from campus.common import devops, env
 from campus.common.utils import datacls
 from campus.model import InternalModel, Model, constraints
 from campus.storage import errors
+from campus.storage.query import gt, gte, is_operator, lt, lte
 
 from ..interface import PK, TableInterface
 
@@ -167,7 +168,10 @@ class PostgreSQLTable(TableInterface):
 
     @staticmethod
     def _build_where_clause(query: dict) -> tuple[str, list]:
-        """Build WHERE clause from query dictionary."""
+        """Build WHERE clause from query dictionary.
+
+        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        """
         if not query:
             return "", []
 
@@ -175,8 +179,24 @@ class PostgreSQLTable(TableInterface):
         params = []
 
         for key, value in query.items():
-            conditions.append(f"{key} = %s")
-            params.append(value)
+            if is_operator(value):
+                # Handle comparison operators
+                if isinstance(value, gt):
+                    conditions.append(f'"{key}" > %s')
+                elif isinstance(value, gte):
+                    conditions.append(f'"{key}" >= %s')
+                elif isinstance(value, lt):
+                    conditions.append(f'"{key}" < %s')
+                elif isinstance(value, lte):
+                    conditions.append(f'"{key}" <= %s')
+                else:
+                    # Unknown operator, fall back to exact match
+                    conditions.append(f'"{key}" = %s')
+                params.append(value.value)
+            else:
+                # Exact match
+                conditions.append(f'"{key}" = %s')
+                params.append(value)
 
         return f"WHERE {' AND '.join(conditions)}", params
 
@@ -215,12 +235,38 @@ class PostgreSQLTable(TableInterface):
                     raise errors.NotFoundError(row_id, self.name)
                 return dict(row)
 
-    def get_matching(self, query: dict) -> list[dict]:
-        """Retrieve rows matching a query."""
+    def get_matching(
+        self,
+        query: dict,
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> list[dict]:
+        """Retrieve rows matching a query.
+
+        Supports exact matches, comparison operators (gt, gte, lt, lte),
+        sorting, and pagination.
+        """
         with self._get_connection() as conn:
             with conn.cursor(cursor_factory=RealDictCursor) as cursor:
                 where_clause, params = self._build_where_clause(query)
                 sql = f"SELECT * FROM {self.name} {where_clause}"
+
+                # Add ORDER BY clause if specified
+                if order_by is not None:
+                    direction = "ASC" if ascending else "DESC"
+                    sql += f' ORDER BY "{order_by}" {direction}'
+
+                # Add LIMIT clause if specified
+                if limit is not None:
+                    sql += f" LIMIT {limit}"
+
+                # Add OFFSET clause if specified
+                if offset > 0:
+                    sql += f" OFFSET {offset}"
+
                 cursor.execute(sql, params)
                 rows = cursor.fetchall()
                 return [dict(row) for row in rows]

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -32,6 +32,7 @@ from campus.common import devops
 from campus.common.utils import datacls
 from campus.model import InternalModel, Model, constraints
 from campus.storage import errors as storage_errors
+from campus.storage.query import gt, gte, is_operator, lt, lte
 from ..interface import TableInterface, PK
 
 
@@ -256,39 +257,77 @@ class SQLiteTable(TableInterface):
             raise storage_errors.NotFoundError(row_id, self.name)
         return row
 
-    def get_matching(self, query: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Retrieve rows matching a query."""
-        cursor = self.get_connection().cursor()
+    @staticmethod
+    def _build_where_clause(query: Dict[str, Any]) -> tuple[str, list]:
+        """Build WHERE clause from query dictionary.
 
+        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        Uses ? placeholders for SQLite parameter binding.
+        """
         if not query:
-            # Return all rows if no query
-            cursor.execute(f"SELECT * FROM {self.name}")
-            return [row for row in (self._deserialize_row(row) for row in cursor.fetchall()) if row is not None]
+            return "", []
 
-        # Simple query handling - exact matches only for this implementation
-        rows = []
-        cursor.execute(f"SELECT * FROM {self.name}")
-        for sqlite_row in cursor.fetchall():
-            row = self._deserialize_row(sqlite_row)
-            if row and self._matches_query(row, query):  # Skip None/empty rows
-                rows.append(row)
+        conditions = []
+        params = []
 
-        return rows
-        rows = []
-        cursor.execute(f"SELECT * FROM {self.name}")
-        for sqlite_row in cursor.fetchall():
-            row = self._deserialize_row(sqlite_row)
-            if row and self._matches_query(row, query):  # Skip empty rows
-                rows.append(row)
-
-        return rows
-
-    def _matches_query(self, row: Dict[str, Any], query: Dict[str, Any]) -> bool:
-        """Check if a row matches a query."""
         for key, value in query.items():
-            if key not in row or row[key] != value:
-                return False
-        return True
+            if is_operator(value):
+                # Handle comparison operators
+                if isinstance(value, gt):
+                    conditions.append(f'"{key}" > ?')
+                elif isinstance(value, gte):
+                    conditions.append(f'"{key}" >= ?')
+                elif isinstance(value, lt):
+                    conditions.append(f'"{key}" < ?')
+                elif isinstance(value, lte):
+                    conditions.append(f'"{key}" <= ?')
+                else:
+                    # Unknown operator, fall back to exact match
+                    conditions.append(f'"{key}" = ?')
+                params.append(value.value)
+            else:
+                # Exact match
+                conditions.append(f'"{key}" = ?')
+                params.append(value)
+
+        return f"WHERE {' AND '.join(conditions)}", params
+
+    def get_matching(
+        self,
+        query: Dict[str, Any],
+        *,
+        order_by: str | None = None,
+        ascending: bool = True,
+        limit: int | None = None,
+        offset: int = 0
+    ) -> List[Dict[str, Any]]:
+        """Retrieve rows matching a query.
+
+        Supports exact matches, comparison operators (gt, gte, lt, lte),
+        sorting, and pagination.
+        """
+        cursor = self.get_connection().cursor()
+        where_clause, params = self._build_where_clause(query)
+        sql = f"SELECT * FROM {self.name} {where_clause}"
+
+        # Add ORDER BY clause if specified
+        if order_by is not None:
+            direction = "ASC" if ascending else "DESC"
+            sql += f' ORDER BY "{order_by}" {direction}'
+
+        # Add LIMIT clause (SQLite requires LIMIT when using OFFSET)
+        # If offset is specified but limit is not, use a very large limit
+        if limit is None and offset > 0:
+            limit = -1  # SQLite uses -1 to mean "no limit"
+        if limit is not None:
+            sql += f" LIMIT {limit}"
+
+        # Add OFFSET clause if specified
+        if offset > 0:
+            sql += f" OFFSET {offset}"
+
+        cursor.execute(sql, params)
+        return [row for row in (self._deserialize_row(row) for row in cursor.fetchall()) if row is not None]
 
     def insert_one(self, row: Dict[str, Any]):
         """Insert a row into the table using actual table columns."""

--- a/tests/unit/storage/test_backends.py
+++ b/tests/unit/storage/test_backends.py
@@ -2,7 +2,7 @@
 """Test the new storage backends for Flask test client strategy."""
 
 import unittest
-from campus.storage import get_table, get_collection
+from campus.storage import get_table, get_collection, gt, gte, lt, lte
 from campus.storage import errors as storage_errors
 from campus.common import env
 
@@ -13,12 +13,36 @@ env.STORAGE_MODE = "1"
 class TestSQLiteBackend(unittest.TestCase):
     """Test the SQLite table backend."""
 
-    def setUp(self):
-        """Set up test table before each test."""
-        self.users_table = get_table("test_users")
+    @classmethod
+    def setUpClass(cls):
+        """Set up test tables once for all tests."""
+        cls.users_table = get_table("test_users")
         # Initialize table schema
         from campus.model import User
-        self.users_table.init_from_model("test_users", User)
+        cls.users_table.init_from_model("test_users", User)
+
+        # Create a test traces table for query operator tests
+        cls.traces_table = get_table("test_traces")
+        cls.traces_table.init_from_schema(
+            'CREATE TABLE IF NOT EXISTS "test_traces" ('
+            '"id" TEXT PRIMARY KEY, '
+            '"created_at" TEXT NOT NULL, '
+            '"duration_ms" INTEGER NOT NULL, '
+            '"status_code" INTEGER NOT NULL);'
+        )
+
+        # Insert test data for query tests
+        test_traces = [
+            {"id": "trace1", "created_at": "2023-01-01T10:00:00Z", "duration_ms": 100, "status_code": 200},
+            {"id": "trace2", "created_at": "2023-01-01T11:00:00Z", "duration_ms": 500, "status_code": 200},
+            {"id": "trace3", "created_at": "2023-01-01T12:00:00Z", "duration_ms": 1500, "status_code": 500},
+            {"id": "trace4", "created_at": "2023-01-01T13:00:00Z", "duration_ms": 2000, "status_code": 500},
+        ]
+        for trace in test_traces:
+            try:
+                cls.traces_table.insert_one(trace)
+            except Exception:
+                pass  # Ignore if already exists
 
     def tearDown(self):
         """Clean up after each test."""
@@ -70,13 +94,135 @@ class TestSQLiteBackend(unittest.TestCase):
             self.users_table.get_by_id("test123")
         self.assertIn("test123", str(cm.exception))
 
+    def test_get_matching_exact_match(self):
+        """get_matching() with exact match query."""
+        results = self.traces_table.get_matching({"status_code": 200})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertEqual(r["status_code"], 200)
+
+    def test_get_matching_with_gt_operator(self):
+        """get_matching() with gt (greater than) operator."""
+        results = self.traces_table.get_matching({"duration_ms": gt(1000)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertGreater(r["duration_ms"], 1000)
+
+    def test_get_matching_with_gte_operator(self):
+        """get_matching() with gte (greater than or equal) operator."""
+        results = self.traces_table.get_matching({"duration_ms": gte(500)})
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertGreaterEqual(r["duration_ms"], 500)
+
+    def test_get_matching_with_lt_operator(self):
+        """get_matching() with lt (less than) operator."""
+        results = self.traces_table.get_matching({"duration_ms": lt(1000)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertLess(r["duration_ms"], 1000)
+
+    def test_get_matching_with_lte_operator(self):
+        """get_matching() with lte (less than or equal) operator."""
+        results = self.traces_table.get_matching({"duration_ms": lte(500)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertLessEqual(r["duration_ms"], 500)
+
+    def test_get_matching_with_multiple_operators(self):
+        """get_matching() with multiple operator conditions (implicit AND)."""
+        results = self.traces_table.get_matching({
+            "status_code": 500,
+            "duration_ms": gt(1000)
+        })
+        # Both trace3 (1500ms) and trace4 (2000ms) match: status=500 AND duration > 1000
+        self.assertEqual(len(results), 2)
+        self.assertIn(results[0]["id"], ["trace3", "trace4"])
+        self.assertIn(results[1]["id"], ["trace3", "trace4"])
+
+    def test_get_matching_with_sorting_ascending(self):
+        """get_matching() with ascending sort."""
+        results = self.traces_table.get_matching(
+            {},
+            order_by="duration_ms",
+            ascending=True
+        )
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0]["duration_ms"], 100)
+        self.assertEqual(results[-1]["duration_ms"], 2000)
+
+    def test_get_matching_with_sorting_descending(self):
+        """get_matching() with descending sort."""
+        results = self.traces_table.get_matching(
+            {},
+            order_by="duration_ms",
+            ascending=False
+        )
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0]["duration_ms"], 2000)
+        self.assertEqual(results[-1]["duration_ms"], 100)
+
+    def test_get_matching_with_limit(self):
+        """get_matching() with limit."""
+        results = self.traces_table.get_matching(
+            {},
+            order_by="duration_ms",
+            ascending=True,
+            limit=2
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["duration_ms"], 100)
+        self.assertEqual(results[1]["duration_ms"], 500)
+
+    def test_get_matching_with_offset(self):
+        """get_matching() with offset."""
+        results = self.traces_table.get_matching(
+            {},
+            order_by="duration_ms",
+            ascending=True,
+            offset=2
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["duration_ms"], 1500)
+        self.assertEqual(results[1]["duration_ms"], 2000)
+
+    def test_get_matching_with_limit_and_offset(self):
+        """get_matching() with both limit and offset (pagination)."""
+        results = self.traces_table.get_matching(
+            {},
+            order_by="duration_ms",
+            ascending=True,
+            limit=2,
+            offset=1
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["duration_ms"], 500)
+        self.assertEqual(results[1]["duration_ms"], 1500)
+
 
 class TestMemoryBackend(unittest.TestCase):
     """Test the memory collection backend."""
 
-    def setUp(self):
-        """Set up test collection before each test."""
-        self.posts_collection = get_collection("test_posts")
+    @classmethod
+    def setUpClass(cls):
+        """Set up test collection once for all tests."""
+        cls.posts_collection = get_collection("test_posts")
+
+        # Create a test metrics collection for query operator tests
+        cls.metrics_collection = get_collection("test_metrics")
+
+        # Insert test data for query tests
+        test_metrics = [
+            {"id": "metric1", "created_at": "2023-01-01T10:00:00Z", "value": 100, "score": 200},
+            {"id": "metric2", "created_at": "2023-01-01T11:00:00Z", "value": 500, "score": 200},
+            {"id": "metric3", "created_at": "2023-01-01T12:00:00Z", "value": 1500, "score": 500},
+            {"id": "metric4", "created_at": "2023-01-01T13:00:00Z", "value": 2000, "score": 500},
+        ]
+        for metric in test_metrics:
+            try:
+                cls.metrics_collection.insert_one(metric)
+            except Exception:
+                pass  # Ignore if already exists
 
     def tearDown(self):
         """Clean up after each test."""
@@ -108,6 +254,111 @@ class TestMemoryBackend(unittest.TestCase):
         retrieved_post = self.posts_collection.get_by_id("post123")
         self.assertEqual(retrieved_post["id"], "post123")
         self.assertEqual(retrieved_post["title"], "Test Post")
+
+    def test_get_matching_exact_match(self):
+        """get_matching() with exact match query."""
+        results = self.metrics_collection.get_matching({"score": 200})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertEqual(r["score"], 200)
+
+    def test_get_matching_with_gt_operator(self):
+        """get_matching() with gt (greater than) operator."""
+        results = self.metrics_collection.get_matching({"value": gt(1000)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertGreater(r["value"], 1000)
+
+    def test_get_matching_with_gte_operator(self):
+        """get_matching() with gte (greater than or equal) operator."""
+        results = self.metrics_collection.get_matching({"value": gte(500)})
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertGreaterEqual(r["value"], 500)
+
+    def test_get_matching_with_lt_operator(self):
+        """get_matching() with lt (less than) operator."""
+        results = self.metrics_collection.get_matching({"value": lt(1000)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertLess(r["value"], 1000)
+
+    def test_get_matching_with_lte_operator(self):
+        """get_matching() with lte (less than or equal) operator."""
+        results = self.metrics_collection.get_matching({"value": lte(500)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertLessEqual(r["value"], 500)
+
+    def test_get_matching_with_multiple_operators(self):
+        """get_matching() with multiple operator conditions (implicit AND)."""
+        results = self.metrics_collection.get_matching({
+            "score": 500,
+            "value": gt(1000)
+        })
+        # Both metric3 (1500) and metric4 (2000) match: score=500 AND value > 1000
+        self.assertEqual(len(results), 2)
+        self.assertIn(results[0]["id"], ["metric3", "metric4"])
+        self.assertIn(results[1]["id"], ["metric3", "metric4"])
+
+    def test_get_matching_with_sorting_ascending(self):
+        """get_matching() with ascending sort."""
+        results = self.metrics_collection.get_matching(
+            {},
+            order_by="value",
+            ascending=True
+        )
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0]["value"], 100)
+        self.assertEqual(results[-1]["value"], 2000)
+
+    def test_get_matching_with_sorting_descending(self):
+        """get_matching() with descending sort."""
+        results = self.metrics_collection.get_matching(
+            {},
+            order_by="value",
+            ascending=False
+        )
+        self.assertEqual(len(results), 4)
+        self.assertEqual(results[0]["value"], 2000)
+        self.assertEqual(results[-1]["value"], 100)
+
+    def test_get_matching_with_limit(self):
+        """get_matching() with limit."""
+        results = self.metrics_collection.get_matching(
+            {},
+            order_by="value",
+            ascending=True,
+            limit=2
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["value"], 100)
+        self.assertEqual(results[1]["value"], 500)
+
+    def test_get_matching_with_offset(self):
+        """get_matching() with offset."""
+        results = self.metrics_collection.get_matching(
+            {},
+            order_by="value",
+            ascending=True,
+            offset=2
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["value"], 1500)
+        self.assertEqual(results[1]["value"], 2000)
+
+    def test_get_matching_with_limit_and_offset(self):
+        """get_matching() with both limit and offset (pagination)."""
+        results = self.metrics_collection.get_matching(
+            {},
+            order_by="value",
+            ascending=True,
+            limit=2,
+            offset=1
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["value"], 500)
+        self.assertEqual(results[1]["value"], 1500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements Phase 2 (all backends) of issue #435 - query operators for storage backends including comparison operators (gt, gte, lt, lte), sorting, and pagination.

## Changes

### Backend Implementations

- **PostgreSQL** (`campus/storage/tables/backend/postgres.py`)
  - Added `_build_where_clause()` to translate operators to SQL WHERE clauses
  - Updated `get_matching()` with sorting and pagination support
  - Updated `update_matching()` and `delete_matching()` to use query builder

- **SQLite** (`campus/storage/tables/backend/sqlite.py`)
  - Added `_build_where_clause()` with `?` placeholders
  - Updated `get_matching()` with sorting and pagination support
  - Fixed: SQLite requires LIMIT when using OFFSET (uses `-1` for no limit)

- **MongoDB** (`campus/storage/documents/backend/mongodb.py`)
  - Added `_build_mongo_query()` to translate operators to MongoDB syntax (`$gt`, `$gte`, `$lt`, `$lte`)
  - Updated `get_matching()` with MongoDB `.sort()`, `.skip()`, `.limit()`
  - Updated `update_matching()` and `delete_matching()` to use query builder

- **Memory** (`campus/storage/documents/backend/memory.py`)
  - Updated `_matches_query()` to handle operators with Python comparisons
  - Updated `get_matching()` with sorting and pagination support

### Features Added

All backends now support:
- **Comparison operators**: `gt`, `gte`, `lt`, `lte`
- **Sorting**: `order_by` and `ascending` parameters
- **Pagination**: `limit` and `offset` parameters

### Tests

- Added 11 new tests for SQLite backend query operators
- Added 11 new tests for Memory backend query operators
- All 133 unit tests passing

## Example Usage

```python
from campus.storage import gt, gte, lt, lte

# Simple exact match (backward compatible)
storage.get_matching({"user_id": "user_123"})

# With operators
storage.get_matching({"duration_ms": gt(1000)})
storage.get_matching({"started_at": gte("2024-01-01"), "status_code": lt(500)})

# With sorting and pagination
storage.get_matching(
    {"status": "active"}, 
    order_by="created_at", 
    ascending=False, 
    limit=10, 
    offset=0
)
```

## Test Plan

- [x] Unit tests pass (133 tests)
- [ ] Integration tests (future work - requires test databases)

## Related Issues

- Closes #435 (Phase 2: Backend Implementation)
- Depends on: #434 (Phase 1: Interface definition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)