### PR TITLE
docs(storage): add query operator and Objects storage documentation

### DIFF
--- a/campus/storage/README.md
+++ b/campus/storage/README.md
@@ -10,8 +10,8 @@ Supported storage models:
 
 Current backends:
 
-* Tables → PostgreSQL
-* Documents → MongoDB
+* Tables → PostgreSQL (production), SQLite (testing)
+* Documents → MongoDB (production), Memory (testing)
 
 ---
 
@@ -58,7 +58,7 @@ docs = events.get_matching({"type": "meeting"})
 Both storage types support similar operations:
 
 * `get_by_id(id)`
-* `get_matching(query)`
+* `get_matching(query, *, order_by, ascending, limit, offset)`
 * `insert_one(data)`
 * `update_by_id(id, update)`
 * `update_matching(query, update)`
@@ -69,6 +69,92 @@ Each record/document is expected to include:
 
 * `id` – primary identifier
 * `created_at` – creation timestamp
+
+---
+
+# Query Operators
+
+The `get_matching()` method supports comparison operators for more expressive queries:
+
+## Available Operators
+
+```python
+from campus.storage import gt, gte, lt, lte
+```
+
+* `gt(value)` – greater than
+* `gte(value)` – greater than or equal
+* `lt(value)` – less than
+* `lte(value)` – less than or equal
+
+## Examples
+
+### Exact Match (Backward Compatible)
+
+```python
+# Simple exact match queries work as before
+traces.get_matching({"user_id": "user_123"})
+traces.get_matching({"status": "active", "type": "request"})
+```
+
+### Comparison Operators
+
+```python
+# Greater than: find slow requests (> 1000ms)
+traces.get_matching({"duration_ms": gt(1000)})
+
+# Greater than or equal: find recent errors
+traces.get_matching({"created_at": gte("2024-01-01"), "status_code": gte(500)})
+
+# Less than: find quick requests
+traces.get_matching({"duration_ms": lt(100)})
+
+# Less than or equal: find old records
+traces.get_matching({"created_at": lte("2024-01-01")})
+```
+
+### Sorting
+
+```python
+from campus.storage import get_table
+
+traces = get_table("traces")
+
+# Ascending sort (default)
+traces.get_matching({}, order_by="created_at")
+
+# Descending sort
+traces.get_matching({}, order_by="created_at", ascending=False)
+
+# Sort by duration
+traces.get_matching({"status": "error"}, order_by="duration_ms", ascending=False)
+```
+
+### Pagination
+
+```python
+# Limit results
+traces.get_matching({}, limit=10)
+
+# Skip first N results
+traces.get_matching({}, offset=20)
+
+# Combined pagination (page 2, 10 per page)
+traces.get_matching({}, order_by="created_at", limit=10, offset=10)
+```
+
+### Combining Filters
+
+Multiple fields are treated as implicit AND (all conditions must match):
+
+```python
+# Find recent error traces from a specific user
+traces.get_matching({
+    "user_id": "user_123",
+    "status_code": gte(500),
+    "created_at": gte("2024-01-01")
+})
+```
 
 ---
 

--- a/campus/storage/README.md
+++ b/campus/storage/README.md
@@ -7,11 +7,13 @@ Supported storage models:
 
 * **Tables** – structured rows with a fixed schema (relational databases)
 * **Documents** – flexible JSON-like objects (document databases)
+* **Objects** – binary blobs with S3-compatible storage (file uploads, images, etc.)
 
 Current backends:
 
 * Tables → PostgreSQL (production), SQLite (testing)
 * Documents → MongoDB (production), Memory (testing)
+* Objects → Railway (production), Local (testing)
 
 ---
 
@@ -51,11 +53,44 @@ events.insert_one({"type": "meeting", "room": "A101"})
 docs = events.get_matching({"type": "meeting"})
 ```
 
+## Objects (Buckets)
+
+```python
+from campus.storage import get_bucket
+
+uploads = get_bucket("uploads")
+
+# Upload a file
+uploads.put("avatar.jpg", image_data, metadata={"content-type": "image/jpeg"})
+
+# Download a file
+data = uploads.get("avatar.jpg")
+
+# Generate a presigned URL (valid for 1 hour)
+url = uploads.get_url("avatar.jpg", expires_in=3600)
+
+# Check if file exists
+if uploads.exists("avatar.jpg"):
+    print("File exists")
+
+# List files with prefix
+files = uploads.list(prefix="user123/", limit=10)
+
+# Get metadata without downloading
+metadata = uploads.get_metadata("avatar.jpg")
+print(f"Size: {metadata.size} bytes")
+
+# Delete a file
+uploads.delete("avatar.jpg")
+```
+
 ---
 
 # Storage Interfaces
 
-Both storage types support similar operations:
+## Tables & Documents
+
+Both Tables and Documents support similar operations:
 
 * `get_by_id(id)`
 * `get_matching(query, *, order_by, ascending, limit, offset)`
@@ -69,6 +104,19 @@ Each record/document is expected to include:
 
 * `id` – primary identifier
 * `created_at` – creation timestamp
+
+## Objects (Buckets)
+
+Buckets provide S3-compatible object storage operations:
+
+* `put(key, data, metadata)` – Upload binary data with optional metadata
+* `get(key)` – Download binary data
+* `delete(key)` – Delete an object
+* `exists(key)` – Check if an object exists
+* `list(prefix, limit)` – List object keys with optional prefix filter
+* `get_url(key, expires_in)` – Generate a presigned URL for temporary access
+* `get_metadata(key)` – Get object metadata without downloading
+* `copy(source_key, dest_key)` – Copy an object within the bucket
 
 ---
 
@@ -184,11 +232,12 @@ except NotFoundError:
 For development/testing only:
 
 ```python
-from campus.storage import purge_tables, purge_collections, purge_all
+from campus.storage import purge_tables, purge_collections, purge_buckets, purge_all
 ```
 
 * `purge_tables()` – delete all table data
 * `purge_collections()` – delete all document data
-* `purge_all()` – delete everything
+* `purge_buckets()` – delete all object storage data
+* `purge_all()` – delete everything (tables, collections, and buckets)
 
 ⚠️ These operations permanently delete data and should **never be used in production**.


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for query operators (gt, gte, lt, lte)
- Add documentation for Objects/Buckets storage interface
- Update backend list to include testing backends (SQLite, Memory, Local)

## Query Operators
- Document comparison operators (gt, gte, lt, lte)
- Add examples for sorting and pagination
- Show combining filters with implicit AND logic
- Update get_matching() signature with new parameters

## Objects/Buckets Storage
- Add Objects to supported storage models
- Document all bucket operations (put, get, delete, exists, list, get_url, get_metadata, copy)
- Add usage examples for file uploads, downloads, and presigned URLs
- Update storage interfaces section with bucket operations
- Add purge_buckets to development utilities

Fixes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)