### PR TITLE
feat(audit): implement routes with resource layer and campus_python auth (#427)

### DIFF
--- a/campus/audit/__init__.py
+++ b/campus/audit/__init__.py
@@ -9,52 +9,78 @@ __all__ = ["init_app"]
 
 from typing import Any
 
+import campus_python
 import flask
 
 from campus.auth.middleware import Authenticator
 from campus.common import env
+from campus.common import schema
 from campus.common.errors import auth_errors
 
 # Other local imports are intentionally omitted to avoid circular
 # dependencies.
 
+# Lazily initialized campus client - set in init_app() after test fixtures are ready
+# This prevents connection to external services during module import in tests
+# Type: ignore because we initialize these in init_app() before first use
+campus: campus_python.Campus = None  # type: ignore
 
-def bearer_authenticate(token: str) -> dict[str, Any]:
-    """Authenticate using HTTP Bearer Authentication with audit API key.
 
-    Validates audit API tokens. For now, this is a placeholder that
-    stores the token in flask.g for later validation.
-
-    TODO: Validate audit token against campus.auth or internal audit API keys.
-    """
-    # TODO: Implement proper audit API key validation
-    # - Check against campus.auth credentials resources
-    # - Or validate against internal audit API keys
-    # For now, store the token in flask.g for later use
+def basic_authenticate(client_id: str, client_secret: str) -> dict[str, Any]:
+    """Authenticate using HTTP Basic Authentication."""
+    try:
+        auth_result = campus.auth.root.authenticate(
+            client_id=schema.CampusID(client_id),
+            client_secret=client_secret
+        )
+    except campus_python.errors.AuthenticationError:
+        raise auth_errors.UnauthorizedClientError(
+            "Invalid client credentials"
+        )
     return {
-        "client": {"client_id": f"audit:{token}"},
+        "client": auth_result["client"],
         "user": None,
     }
 
 
-# Create authenticator for audit (Bearer-only for API keys)
+def bearer_authenticate(token: str) -> dict[str, Any]:
+    """Authenticate using HTTP Bearer Authentication."""
+    try:
+        auth_result = campus.auth.root.authenticate(token=token)
+    except campus_python.errors.AuthenticationError:
+        raise auth_errors.UnauthorizedClientError(
+            "Invalid access token"
+        )
+    return {
+        "client": auth_result["client"],
+        "user": auth_result.get("user"),
+    }
+
+
+# Create authenticator using campus_python (same as campus.api)
 audit_authenticator = Authenticator(
-    basic_authenticator=lambda client_id, client_secret: (_ for _ in ()).throw(
-        auth_errors.InvalidRequestError("Only Bearer authentication supported for audit service")
-    ),
+    basic_authenticator=basic_authenticate,
     bearer_authenticator=bearer_authenticate,
 )
 
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
     """Initialise the audit blueprint with the given Flask app."""
+    # Initialize campus client after test fixtures have set up the vault
+    global campus
+    campus = campus_python.Campus(timeout=60)
+
     from . import routes
+
+    # Create route blueprints using create_blueprint() for test isolation
+    traces_blueprint = routes.traces.create_blueprint()
+    health_blueprint = routes.health.create_blueprint()
 
     # Organise audit routes under audit blueprint
     bp = flask.Blueprint('audit_v1', __name__, url_prefix='/audit/v1')
 
     # Register authenticated routes (traces)
-    routes.traces.init_app(bp)
+    bp.register_blueprint(traces_blueprint)
 
     # Apply authentication to the traces blueprint
     # Note: We apply to the traces blueprint directly so that health
@@ -62,7 +88,7 @@ def init_app(app: flask.Flask | flask.Blueprint) -> None:
     bp.before_request(audit_authenticator.authenticate)
 
     # Register public health routes WITHOUT authentication
-    routes.health.init_app(bp)
+    bp.register_blueprint(health_blueprint)
 
     app.register_blueprint(bp)
 

--- a/campus/audit/middleware/__init__.py
+++ b/campus/audit/middleware/__init__.py
@@ -38,7 +38,7 @@ def init_app(app: flask.Flask) -> None:
     def end_span(response):
         """Complete the span and send to audit service.
 
-        Builds TraceSpan from request/response data and ingests asynchronously.
+        Builds TraceSpan from request-response data and ingests asynchronously.
         Echoes trace_id in response headers for correlation.
 
         Args:

--- a/campus/audit/resources/traces.py
+++ b/campus/audit/resources/traces.py
@@ -20,61 +20,22 @@ import campus.storage
 traces_storage = campus.storage.tables.get_db("spans")
 
 
-def _build_span_tree(spans: list[dict]) -> dict | None:
+def _build_trace_tree(spans: list[dict]) -> model.TraceTree | None:
     """Build a hierarchical tree from flat span list.
 
     Args:
         spans: Flat list of span records from storage
 
     Returns:
-        Root span with nested children, or None if no spans
+        TraceTree with root and nested children, or None if no spans
     """
     if not spans:
         return None
 
-    # Build span map for O(1) lookup
-    span_map = {s["span_id"]: {**s, "children": []} for s in spans}
-
-    # Find root and organize children
-    root = None
-    for span in spans:
-        span_id = span["span_id"]
-        parent_id = span.get("parent_span_id")
-        if parent_id is None:
-            root = span_map[span_id]
-        elif parent_id in span_map:
-            span_map[parent_id]["children"].append(span_map[span_id])
-
-    # Calculate tree metrics (depth, offset)
-    if root:
-        _calculate_tree_metrics(root, 0, 0)
-
-    return root
+    return model.TraceTree.from_spans(spans)
 
 
-def _calculate_tree_metrics(span: dict, depth: int, offset: float) -> float:
-    """Calculate depth and offset for each span in tree.
-
-    Args:
-        span: Span node with children
-        depth: Current depth in tree
-        offset: Current offset from parent start
-
-    Returns:
-        Total duration of this span subtree
-    """
-    span["depth"] = depth
-    span["offset"] = offset
-
-    children_duration = 0
-    for child in span.get("children", []):
-        child_duration = _calculate_tree_metrics(child, depth + 1, children_duration)
-        children_duration = max(children_duration, child_duration)
-
-    return max(span.get("duration_ms", 0), children_duration)
-
-
-def _build_trace_summaries(spans: list[dict]) -> list[dict]:
+def _build_trace_summaries(spans: list[dict]) -> list[model.TraceSummary]:
     """Build trace summaries from span list.
 
     Groups spans by trace_id and creates summary records.
@@ -83,7 +44,7 @@ def _build_trace_summaries(spans: list[dict]) -> list[dict]:
         spans: Flat list of span records
 
     Returns:
-        List of trace summary dictionaries
+        List of TraceSummary instances
     """
     # Group spans by trace_id
     traces: dict[str, list[dict]] = {}
@@ -93,30 +54,11 @@ def _build_trace_summaries(spans: list[dict]) -> list[dict]:
             traces[trace_id] = []
         traces[trace_id].append(span)
 
-    # Build summaries
-    summaries = []
-    for trace_id, trace_spans in traces.items():
-        root_span = next((s for s in trace_spans if s.get("parent_span_id") is None), None)
-        if root_span:
-            summaries.append({
-                "trace_id": trace_id,
-                "span_count": len(trace_spans),
-                "started_at": root_span["started_at"],
-                "duration_ms": root_span["duration_ms"],
-                "root_span": model.TraceSpan.from_storage(root_span),
-            })
-        else:
-            # No root span, use earliest span
-            earliest = min(trace_spans, key=lambda s: s["started_at"])
-            summaries.append({
-                "trace_id": trace_id,
-                "span_count": len(trace_spans),
-                "started_at": earliest["started_at"],
-                "duration_ms": sum(s.get("duration_ms", 0) for s in trace_spans),
-                "root_span": model.TraceSpan.from_storage(earliest),
-            })
-
-    return summaries
+    # Build summaries using TraceSummary.from_spans
+    return [
+        model.TraceSummary.from_spans(trace_id, trace_spans)
+        for trace_id, trace_spans in traces.items()
+    ]
 
 
 class TracesResource:
@@ -169,7 +111,7 @@ class TracesResource:
         since: str | None = None,
         until: str | None = None,
         limit: int = 50,
-    ) -> "list[dict]":
+    ) -> list[model.TraceSummary]:
         """List traces newest first with optional time range filter.
 
         Args:
@@ -178,7 +120,7 @@ class TracesResource:
             limit: Maximum number of traces to return
 
         Returns:
-            List of trace summary dictionaries
+            List of TraceSummary model instances
         """
         query = {}
         if since:
@@ -208,7 +150,7 @@ class TracesResource:
         since: str | None = None,
         until: str | None = None,
         limit: int = 50,
-    ) -> "list[dict]":
+    ) -> typing.List[model.TraceSummary]:
         """Search traces by multiple filter criteria.
 
         Args:
@@ -222,7 +164,7 @@ class TracesResource:
             limit: Maximum number of traces to return
 
         Returns:
-            List of trace summary dictionaries
+            List of TraceSummary model instances
         """
         query = {}
         if path:
@@ -261,7 +203,7 @@ class TracesResource:
 class TraceResource:
     """Represents a single trace in Campus audit API.
 
-    Maps to URL path: /traces/{trace_id}
+    Maps to URL path: /traces/{trace_id}/
     """
 
     def __init__(self, trace_id: str):
@@ -284,24 +226,24 @@ class TraceResource:
             )
         return TraceSpansResource(self)
 
-    def get_tree(self) -> dict | None:
+    def get_tree(self) -> model.TraceTree | None:
         """Get full trace tree with nested children.
 
         Returns:
-            Root span with nested children array, or None if not found
+            TraceTree with root and nested children, or None if not found
         """
         try:
             spans = traces_storage.get_matching({"trace_id": self.trace_id})
         except campus.storage.errors.StorageError as e:
             raise api_errors.InternalError.from_exception(e)
 
-        return _build_span_tree(spans)
+        return _build_trace_tree(spans)
 
-    def get(self) -> dict | None:
+    def get(self) -> model.TraceTree | None:
         """Get trace summary (alias for get_tree).
 
         Returns:
-            Trace tree or None
+            TraceTree or None
         """
         return self.get_tree()
 
@@ -318,7 +260,7 @@ class TraceSpansResource:
     def __getitem__(self, span_id: str) -> "SpanResource":
         """Get a single span by span_id.
 
-        Maps to URL path: /traces/{trace_id}/spans/{span_id}
+        Maps to URL path: /traces/{trace_id}/spans/{span_id}/
 
         Args:
             span_id: The 16-char hex span identifier
@@ -328,7 +270,7 @@ class TraceSpansResource:
         """
         return SpanResource(self, span_id)
 
-    def list(self) -> "list[model.TraceSpan]":
+    def list(self) -> list[model.TraceSpan]:
         """List all spans in the trace (flat list).
 
         Returns:

--- a/campus/audit/routes/__init__.py
+++ b/campus/audit/routes/__init__.py
@@ -1,6 +1,13 @@
 """campus.audit.routes
 
-This is a namespace module for the Campus audit API routes.
+Flask blueprint modules for the audit service.
+
+This package contains all HTTP route definitions organized by functionality:
+- traces.py: Trace ingestion and query endpoints (/traces/*)
+- health.py: Health check endpoint (/health)
+
+Each module defines route functions that can be attached to blueprints
+dynamically. This allows creating fresh blueprints for test isolation.
 """
 
 __all__ = [

--- a/campus/audit/routes/health.py
+++ b/campus/audit/routes/health.py
@@ -9,20 +9,8 @@ import flask
 
 from campus import flask_campus
 
-# Create blueprint for health check routes
-bp = flask.Blueprint('audit_health', __name__)
 
-
-def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialize health check routes.
-
-    Args:
-        app: The Flask app or blueprint to register routes on.
-    """
-    app.register_blueprint(bp)
-
-
-@bp.get("/health")
+@flask.Blueprint('audit_health', __name__).get("/health")
 def health_check() -> flask_campus.JsonResponse:
     """Health check endpoint (no authentication required).
 
@@ -30,9 +18,18 @@ def health_check() -> flask_campus.JsonResponse:
         - 200 OK with {"status": "ok"} for JSON Accept header
         - 200 OK with "OK" plain text for text/plain Accept header
     """
-    # TODO: Implement health check logic
-    # - Check Accept header for content negotiation
-    # - Return JSON for application/json
-    # - Return plain text for text/plain
-    # - No authentication required
     return {"status": "ok"}, 200
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('audit_health', __name__)
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/health", "health_check", health_check, methods=["GET"])
+
+    return new_bp

--- a/campus/audit/routes/traces.py
+++ b/campus/audit/routes/traces.py
@@ -9,19 +9,13 @@ from typing import Any
 
 import flask
 
-from campus import flask_campus
+import campus.flask_campus as flask_campus
+from campus.common.errors import api_errors
+
+from ..resources import traces as traces_resource
 
 # Create blueprint for trace routes
 bp = flask.Blueprint('audit_traces', __name__, url_prefix='/traces')
-
-
-def init_app(app: flask.Flask | flask.Blueprint) -> None:
-    """Initialize trace routes.
-
-    Args:
-        app: The Flask app or blueprint to register routes on.
-    """
-    app.register_blueprint(bp)
 
 
 @bp.post("/")
@@ -69,13 +63,14 @@ def ingest_spans(
         207 Multi-Status on partial failure
         400 Bad Request on invalid input
     """
-    # TODO: Implement span ingestion
-    # - Validate request body schema
-    # - Insert spans to database via resources.traces
-    # - Handle batch partial failures (207 Multi-Status)
-    # - Return inserted span IDs
-    _ = spans  # TODO: Use spans parameter in implementation
-    return {}, 201
+    # Convert dicts to TraceSpan models
+    import campus.model as model
+    span_models = [
+        model.TraceSpan.from_resource(span_dict)
+        for span_dict in spans
+    ]
+    result = traces_resource.ingest(span_models)
+    return result, 201
 
 
 @bp.get("/")
@@ -101,13 +96,11 @@ def list_traces(
         JSON: {"traces": [...], "cursor": {"next": "...", "has_more": true}}
         Text: Compact trace list with pagination hint
     """
-    # TODO: Implement trace listing
-    # - Parse query params (since, until, limit)
-    # - Check Accept header for content negotiation
-    # - Query traces via resources.traces
-    # - Return JSON or plain text format
-    _ = since, until, limit  # TODO: Use parameters in implementation
-    return {"traces": [], "cursor": {"next": None, "has_more": False}}, 200
+    summaries = traces_resource.list(since=since, until=until, limit=limit)
+    return {
+        "traces": [s.to_resource() for s in summaries],
+        "cursor": {"next": None, "has_more": False}
+    }, 200
 
 
 @bp.get("/<trace_id>/")
@@ -125,12 +118,26 @@ def get_trace(trace_id: str) -> flask_campus.JsonResponse:
         JSON: Trace tree with nested children
         Text: Waterfall visualization showing timing hierarchy
     """
-    # TODO: Implement trace tree retrieval
-    # - Validate trace_id format (32 hex chars)
-    # - Build tree from spans via recursive CTE
-    # - Calculate offset, duration, depth for each span
-    # - Return JSON or text waterfall format
-    return {}, 200
+    tree = traces_resource[trace_id].get_tree()
+    if tree is None:
+        raise api_errors.NotFoundError(f"Trace {trace_id} not found")
+    return tree.to_resource(), 200
+
+
+@bp.get("/<trace_id>/spans/")
+def list_spans(trace_id: str) -> flask_campus.JsonResponse:
+    """List all spans in a trace (flat list).
+
+    Args:
+        trace_id: The 32-char hex trace identifier
+
+    Returns:
+        Flat list of all spans in the trace
+    """
+    spans = traces_resource[trace_id]["spans"].list()
+    return {
+        "spans": [s.to_resource() for s in spans]
+    }, 200
 
 
 @bp.get("/<trace_id>/spans/<span_id>/")
@@ -144,11 +151,12 @@ def get_span(trace_id: str, span_id: str) -> flask_campus.JsonResponse:
     Returns:
         Full span data including request/response headers and bodies
     """
-    # TODO: Implement single span retrieval
-    # - Validate trace_id and span_id formats
-    # - Query span by trace_id and span_id
-    # - Return full span detail
-    return {}, 200
+    span = traces_resource[trace_id]["spans"][span_id].get()
+    if span is None:
+        raise api_errors.NotFoundError(
+            f"Span {span_id} not found in trace {trace_id}"
+        )
+    return span.to_resource(), 200
 
 
 @bp.get("/search")
@@ -156,7 +164,7 @@ def get_span(trace_id: str, span_id: str) -> flask_campus.JsonResponse:
 def search_traces(
     *,
     path: str | None = None,
-    status: str | None = None,
+    status: int | None = None,
     api_key_id: str | None = None,
     client_id: str | None = None,
     user_id: str | None = None,
@@ -168,7 +176,7 @@ def search_traces(
 
     Query params:
         path: Filter by endpoint path
-        status: Filter by status (e.g. "5xx", "4xx", "200")
+        status: Filter by HTTP status code
         api_key_id: Filter by API key
         client_id: Filter by OAuth client
         user_id: Filter by user
@@ -181,10 +189,36 @@ def search_traces(
     Returns:
         Filtered trace list matching criteria
     """
-    # TODO: Implement trace search
-    # - Parse and validate filter parameters
-    # - Build query from filters
-    # - Check Accept header for content negotiation
-    # - Return filtered traces
-    _ = path, status, api_key_id, client_id, user_id, since, until, limit  # TODO: Use parameters in implementation
-    return {"traces": [], "cursor": {"next": None, "has_more": False}}, 200
+    summaries = traces_resource.search(
+        path=path,
+        status=status,
+        api_key_id=api_key_id,
+        client_id=client_id,
+        user_id=user_id,
+        since=since,
+        until=until,
+        limit=limit,
+    )
+    return {
+        "traces": [s.to_resource() for s in summaries],
+        "cursor": {"next": None, "has_more": False}
+    }, 200
+
+
+def create_blueprint() -> flask.Blueprint:
+    """Create a fresh blueprint with routes for test isolation.
+
+    Creates a new blueprint instance and manually registers all route
+    functions to support creating multiple independent Flask apps.
+    """
+    new_bp = flask.Blueprint('audit_traces', __name__, url_prefix='/traces')
+
+    # Manually register routes (mimicking the decorator behavior)
+    new_bp.add_url_rule("/", "ingest_spans", ingest_spans, methods=["POST"])
+    new_bp.add_url_rule("/", "list_traces", list_traces, methods=["GET"])
+    new_bp.add_url_rule("/<trace_id>/", "get_trace", get_trace, methods=["GET"])
+    new_bp.add_url_rule("/<trace_id>/spans/", "list_spans", list_spans, methods=["GET"])
+    new_bp.add_url_rule("/<trace_id>/spans/<span_id>/", "get_span", get_span, methods=["GET"])
+    new_bp.add_url_rule("/search", "search_traces", search_traces, methods=["GET"])
+
+    return new_bp


### PR DESCRIPTION
## Summary
- Implement audit routes using the resource layer pattern from campus.auth/api
- Update authentication to use campus_python for validation
- Add create_blueprint() pattern for test isolation

## Changes
- **campus/audit/__init__.py**: Use campus_python.Campus for authentication
  - `basic_authenticate` and `bearer_authenticate` call `campus.auth.root.authenticate`
  - Use `create_blueprint()` pattern for test isolation
  - Same pattern as campus.api
- **campus/audit/routes/traces.py**: Implement routes using resources
  - `ingest_spans`: Convert dicts to TraceSpan models, call `resources.ingest()`
  - `list_traces`: Call `resources.list()` and serialize with `to_resource()`
  - `get_trace`: Call `resources[trace_id].get_tree()` for tree structure
  - `list_spans`: Call `resources[trace_id]["spans"].list()`
  - `get_span`: Call `resources[trace_id]["spans"][span_id].get()`
  - `search_traces`: Call `resources.search()` with filters
  - Add `create_blueprint()` for test isolation
  - Fix status parameter type from str to int
- **campus/audit/routes/health.py**: Add `create_blueprint()`
- **campus/audit/routes/__init__.py**: Simplify to just export modules

Routes now use the resource layer which returns model instances (TraceTree, TraceSummary, TraceSpan), and routes call `to_resource()` for JSON serialization.

## Test Plan
- [x] Type checks pass (pyright)
- [x] Unit tests pass
- [x] Integration tests pass

Addresses issue #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)