### PR TITLE
Add between operator for inclusive range queries

### DIFF
--- a/campus/storage/__init__.py
+++ b/campus/storage/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "gte",
     "lt",
     "lte",
+    "between",
     "is_operator",
 ]
 
@@ -45,7 +46,7 @@ from .errors import (
     NotFoundError,
     NoChangesAppliedError
 )
-from .query import gt, gte, lt, lte, is_operator
+from .query import gt, gte, lt, lte, between, is_operator
 
 
 def get_table(name: str) -> TableInterface:

--- a/campus/storage/query.py
+++ b/campus/storage/query.py
@@ -6,7 +6,7 @@ These operators enable more expressive queries while maintaining backward
 compatibility with simple exact-match queries.
 
 Example:
-    from campus.storage.query import gt, gte, lt, lte
+    from campus.storage.query import gt, gte, lt, lte, between
 
     # Simple exact match (backward compatible)
     storage.get_matching({"user_id": "user_123"})
@@ -15,6 +15,7 @@ Example:
     storage.get_matching({"duration_ms": gt(1000)})
     storage.get_matching({"started_at": gte("2024-01-01")})
     storage.get_matching({"status_code": lt(500)})
+    storage.get_matching({"started_at": between("2024-01-01", "2024-12-31")})
 """
 
 from dataclasses import dataclass
@@ -61,6 +62,23 @@ class lte(Operator):
     Example:
         {"retries": lte(3)}  # retries <= 3
     """
+
+
+@dataclass(frozen=True)
+class between(Operator):
+    """Range comparison for inclusive lower and upper bounds.
+
+    Example:
+        {"started_at": between("2024-01-01", "2024-12-31")}  # 2024-01-01 <= started_at <= 2024-12-31
+
+    Attributes:
+        value: A tuple of (min_value, max_value) representing the inclusive range
+    """
+    value: tuple[Any, Any]
+
+    def __init__(self, min_value: Any, max_value: Any):
+        # Use object.__setattr__ since dataclass is frozen
+        object.__setattr__(self, "value", (min_value, max_value))
 
 
 def is_operator(value: Any) -> bool:

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -261,7 +261,7 @@ class SQLiteTable(TableInterface):
     def _build_where_clause(query: Dict[str, Any]) -> tuple[str, list]:
         """Build WHERE clause from query dictionary.
 
-        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        Handles exact matches and comparison operators (gt, gte, lt, lte, between).
         Uses ? placeholders for SQLite parameter binding.
         """
         if not query:
@@ -270,21 +270,31 @@ class SQLiteTable(TableInterface):
         conditions = []
         params = []
 
+        from campus.storage.query import between as between_op
         for key, value in query.items():
             if is_operator(value):
                 # Handle comparison operators
                 if isinstance(value, gt):
                     conditions.append(f'"{key}" > ?')
+                    params.append(value.value)
                 elif isinstance(value, gte):
                     conditions.append(f'"{key}" >= ?')
+                    params.append(value.value)
                 elif isinstance(value, lt):
                     conditions.append(f'"{key}" < ?')
+                    params.append(value.value)
                 elif isinstance(value, lte):
                     conditions.append(f'"{key}" <= ?')
+                    params.append(value.value)
+                elif isinstance(value, between_op):
+                    # BETWEEN operator: key >= min AND key <= max
+                    min_val, max_val = value.value
+                    conditions.append(f'("{key}" >= ? AND "{key}" <= ?)')
+                    params.extend([min_val, max_val])
                 else:
                     # Unknown operator, fall back to exact match
                     conditions.append(f'"{key}" = ?')
-                params.append(value.value)
+                    params.append(value.value)
             else:
                 # Exact match
                 conditions.append(f'"{key}" = ?')

--- a/tests/unit/storage/test_backends.py
+++ b/tests/unit/storage/test_backends.py
@@ -199,6 +199,28 @@ class TestSQLiteBackend(unittest.TestCase):
         self.assertEqual(results[0]["duration_ms"], 500)
         self.assertEqual(results[1]["duration_ms"], 1500)
 
+    def test_get_matching_with_between_operator(self):
+        """get_matching() with between operator for inclusive range."""
+        from campus.storage import between
+        # Query for traces with duration_ms between 500 and 1500 (inclusive)
+        results = self.traces_table.get_matching({"duration_ms": between(500, 1500)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertGreaterEqual(r["duration_ms"], 500)
+            self.assertLessEqual(r["duration_ms"], 1500)
+
+    def test_get_matching_with_between_operator_string_field(self):
+        """get_matching() with between operator on string/timestamp field."""
+        from campus.storage import between
+        # Query for traces created between 11:00 and 13:00
+        results = self.traces_table.get_matching({
+            "created_at": between("2023-01-01T11:00:00Z", "2023-01-01T13:00:00Z")
+        })
+        self.assertEqual(len(results), 2)
+        # Should return trace2 (11:00) and trace3 (12:00)
+        self.assertIn(results[0]["id"], ["trace2", "trace3"])
+        self.assertIn(results[1]["id"], ["trace2", "trace3"])
+
 
 class TestMemoryBackend(unittest.TestCase):
     """Test the memory collection backend."""


### PR DESCRIPTION
## Summary
- Adds `between` operator for inclusive range queries
- Enables time-range queries without losing either bound

## Changes
- `campus/storage/query.py`: Add `between` operator class
- `campus/storage/__init__.py`: Export `between`
- `campus/storage/tables/backend/sqlite.py`: Handle `between` in WHERE clauses
- `tests/unit/storage/test_backends.py`: Add unit tests

## Usage
```python
from campus.storage import between

# Inclusive range: 2024-01-01 <= started_at <= 2024-12-31
query = {"started_at": between("2024-01-01", "2024-12-31")}
```

## Related
- Part of #435 (Extend campus.storage query capabilities)
- Enables fix for issue #426 (Traces time range filtering bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)