### PR TITLE
feat(audit): add internal audit API client

### DIFF
--- a/campus/audit/client/interface.py
+++ b/campus/audit/client/interface.py
@@ -92,14 +92,15 @@ class ResourceCollection:
         """Create a full path for a sub-resource or action."""
         if part:
             return (
-                f"/{self.root.make_path(self.path).lstrip(SLASH).rstrip(SLASH)}"
+                f"/{self.root.url_prefix.lstrip(SLASH)}"
+                f"/{self.path.lstrip(SLASH).rstrip(SLASH)}"
                 f"/{part.lstrip(SLASH)}"
             )
-        return f"/{self.root.make_path(self.path).lstrip(SLASH)}"
+        return f"/{self.root.url_prefix.lstrip(SLASH)}/{self.path.lstrip(SLASH)}"
 
     def make_url(self, part: str | None = None) -> str:
         """Create a full URL for a sub-resource or action."""
-        return f"{self.root.make_url()}{self.make_path(part)}"
+        return f"{self.root.base_url}{self.make_path(part)}"
 
 
 class Resource:

--- a/campus/audit/client/v1/traces.py
+++ b/campus/audit/client/v1/traces.py
@@ -13,7 +13,7 @@ URL path mapping:
 from typing import Optional, Any
 
 from campus.common.http.interface import JsonClient, JsonResponse
-from ..interface import ResourceCollection, Resource, ResourceRoot
+from ..interface import ResourceCollection, Resource, ResourceRoot, SLASH
 
 
 class Traces(ResourceCollection):
@@ -178,18 +178,13 @@ class Traces(ResourceCollection):
                 trace_id: The trace identifier.
                 parent: The parent traces resource.
             """
+            super().__init__(trace_id, parent=parent, root=parent.root)
             self.trace_id = trace_id
-            self.path = parent.make_path(trace_id)
 
         @property
         def client(self) -> JsonClient:
             """Get the JsonClient associated with this resource."""
             return self.parent.client
-
-        @property
-        def root(self) -> ResourceRoot:
-            """Get the root resource."""
-            return self.parent.root
 
         def get_tree(self) -> JsonResponse:
             """Get the trace tree with hierarchical span structure.
@@ -231,16 +226,33 @@ class Traces(ResourceCollection):
                 trace_id: The trace identifier.
                 parent: The parent trace resource.
             """
-            self.trace_id = trace_id
+            self._client = None  # Will use parent's client
+            # ResourceCollection requires root and path to be set
+            self.root = parent.root
             self.path = "spans/"
             self.parent = parent
-            self.root = parent.root
-            self._client = None  # Will use parent's client
+            self.trace_id = trace_id
 
         @property
         def client(self) -> JsonClient:
             """Get the JsonClient associated with this resource."""
             return self.parent.client
+
+        def make_path(self, part: str | None = None) -> str:
+            """Create a full path for a sub-resource or action.
+
+            Override because Spans is nested under Trace (not directly under root).
+            """
+            if part:
+                return (
+                    f"{self.parent.path.rstrip(SLASH)}"
+                    f"/{self.path.lstrip(SLASH).rstrip(SLASH)}"
+                    f"/{part.lstrip(SLASH)}"
+                )
+            return (
+                f"{self.parent.path.rstrip(SLASH)}"
+                f"/{self.path.lstrip(SLASH)}"
+            )
 
         def list(self) -> JsonResponse:
             """List all spans in the trace (flat list).
@@ -282,19 +294,13 @@ class Traces(ResourceCollection):
                     span_id: The span identifier.
                     parent: The parent spans resource.
                 """
+                super().__init__(span_id, parent=parent, root=parent.root)
                 self.span_id = span_id
-                self.trace_id = parent.trace_id
-                self.path = parent.make_path(span_id)
 
             @property
             def client(self) -> JsonClient:
                 """Get the JsonClient associated with this resource."""
                 return self.parent.client
-
-            @property
-            def root(self) -> ResourceRoot:
-                """Get the root resource."""
-                return self.parent.root
 
             def get(self) -> JsonResponse:
                 """Get the span details.

--- a/tests/unit/audit/test_client.py
+++ b/tests/unit/audit/test_client.py
@@ -1,0 +1,62 @@
+"""Unit tests for campus.audit.client module.
+
+These tests verify that the audit HTTP client fulfills its interface contracts
+and properly constructs API requests to the audit service.
+
+Test Principles:
+- Test interface contracts, not implementation
+- Test resource chaining and path construction
+- Do not test actual HTTP requests (those are contract tests)
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from campus.audit.client import AuditClient
+
+
+class TestAuditClientInitialization(unittest.TestCase):
+    """Test AuditClient initialization and configuration."""
+
+    @patch("campus.audit.client._get_base_url")
+    @patch("campus.audit.client.DefaultClient")
+    def test_client_initialization(self, mock_client_class, mock_get_base_url):
+        """Test that AuditClient initializes with proper configuration."""
+        mock_get_base_url.return_value = "https://audit.test"
+        mock_http_client = Mock()
+        mock_client_class.return_value = mock_http_client
+
+        client = AuditClient()
+
+        # Verify _get_base_url was called
+        mock_get_base_url.assert_called_once()
+        # Verify DefaultClient was instantiated with correct base_url
+        mock_client_class.assert_called_once_with(base_url="https://audit.test")
+
+
+class TestAuditClientResources(unittest.TestCase):
+    """Test AuditClient resource access."""
+
+    @patch("campus.audit.client._get_base_url")
+    @patch("campus.audit.client.DefaultClient")
+    def test_traces_property_returns_traces_resource(self, mock_client_class, mock_get_base_url):
+        """Test that client.traces returns Traces resource."""
+        mock_get_base_url.return_value = "https://audit.test"
+        mock_http_client = Mock()
+        mock_http_client.base_url = "https://audit.test"
+        mock_client_class.return_value = mock_http_client
+
+        client = AuditClient()
+
+        # Access traces property
+        traces = client.traces
+
+        # Verify it's a Traces resource
+        from campus.audit.client.v1.traces import Traces
+        self.assertIsInstance(traces, Traces)
+        self.assertEqual(traces.root, client._root)
+        self.assertEqual(traces.client, mock_http_client)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/audit/test_interface.py
+++ b/tests/unit/audit/test_interface.py
@@ -1,0 +1,198 @@
+"""Unit tests for campus.audit.client.interface module.
+
+These tests verify that the base resource classes (ResourceRoot, ResourceCollection,
+Resource) properly handle path construction and client propagation.
+
+Test Principles:
+- Test path construction with trailing slashes
+- Test client propagation from parent to child
+- Test bracket access patterns
+"""
+
+import unittest
+
+from campus.audit.client.interface import ResourceRoot, ResourceCollection, Resource
+from unittest.mock import Mock
+
+
+class MockJsonClient:
+    """Mock JsonClient for testing."""
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+
+
+class TestResourceRoot(unittest.TestCase):
+    """Test ResourceRoot base class."""
+
+    def test_resource_root_base_url(self):
+        """Test that base_url property returns client's base_url."""
+        client = MockJsonClient("https://audit.test")
+        root = ResourceRoot(json_client=client)
+
+        self.assertEqual(root.base_url, "https://audit.test")
+
+    def test_resource_root_client_property(self):
+        """Test that client property returns the JsonClient."""
+        client = MockJsonClient("https://audit.test")
+        root = ResourceRoot(json_client=client)
+
+        self.assertEqual(root.client, client)
+
+    def test_resource_root_make_path(self):
+        """Test that make_path constructs correct paths."""
+        client = MockJsonClient("https://audit.test")
+        root = ResourceRoot(json_client=client)
+        root.url_prefix = "api/v1"
+
+        # Base path
+        self.assertEqual(root.make_path(), "/api/v1")
+
+        # With sub-path
+        self.assertEqual(root.make_path("users"), "/api/v1/users")
+
+    def test_resource_root_make_url(self):
+        """Test that make_url constructs full URLs."""
+        client = MockJsonClient("https://audit.test")
+        root = ResourceRoot(json_client=client)
+        root.url_prefix = "api/v1"
+
+        self.assertEqual(root.make_url(), "https://audit.test/api/v1")
+
+
+class MockCollection(ResourceCollection):
+    """Mock ResourceCollection for testing."""
+    path = "users/"
+
+    def __init__(self, client=None, *, root: ResourceRoot):
+        self._client = client
+        self.root = root
+
+
+class TestResourceCollection(unittest.TestCase):
+    """Test ResourceCollection base class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = MockJsonClient("https://audit.test")
+        self.root = ResourceRoot(json_client=self.client)
+        self.root.url_prefix = "api/v1"
+
+    def test_resource_collection_path_must_have_trailing_slash(self):
+        """Test that ResourceCollection path must have trailing slash."""
+        # Valid path
+        collection = MockCollection(client=self.client, root=self.root)
+        self.assertTrue(collection.path.endswith("/"))
+
+        # Invalid path should raise ValueError
+        class InvalidCollection(ResourceCollection):
+            path = "users"  # No trailing slash
+
+        with self.assertRaises(ValueError):
+            InvalidCollection(client=self.client, root=self.root)
+
+    def test_resource_collection_make_path(self):
+        """Test that make_path constructs correct paths."""
+        collection = MockCollection(client=self.client, root=self.root)
+
+        # Base path
+        self.assertEqual(collection.make_path(), "/api/v1/users/")
+
+        # With sub-path
+        self.assertEqual(collection.make_path("123"), "/api/v1/users/123")
+
+    def test_resource_collection_make_url(self):
+        """Test that make_url constructs full URLs."""
+        collection = MockCollection(client=self.client, root=self.root)
+
+        self.assertEqual(collection.make_url(), "https://audit.test/api/v1/users/")
+        self.assertEqual(collection.make_url("123"), "https://audit.test/api/v1/users/123")
+
+    def test_resource_collection_client_propagation(self):
+        """Test that client property returns parent's client."""
+        collection = MockCollection(client=None, root=self.root)
+
+        self.assertEqual(collection.client, self.client)
+
+    def test_resource_collection_root_property(self):
+        """Test that root property returns the root resource."""
+        collection = MockCollection(client=self.client, root=self.root)
+
+        self.assertEqual(collection.root, self.root)
+
+
+class MockResource(Resource):
+    """Mock Resource for testing."""
+    def __init__(self, *parts, parent: Resource, root: ResourceRoot, client=None):
+        super().__init__(*parts, parent=parent, root=root, client=client)
+
+
+class TestResource(unittest.TestCase):
+    """Test Resource base class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.client = MockJsonClient("https://audit.test")
+        self.root = ResourceRoot(json_client=self.client)
+        self.root.url_prefix = "api/v1"
+        self.collection = MockCollection(client=self.client, root=self.root)
+
+    def test_resource_path_construction(self):
+        """Test that path is constructed from parent + parts."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.path, "/api/v1/users/123")
+
+    def test_resource_with_multiple_parts(self):
+        """Test path construction with multiple parts."""
+        resource = MockResource("123", "profile", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.path, "/api/v1/users/123/profile")
+
+    def test_resource_make_path(self):
+        """Test that make_path constructs sub-resource paths."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.make_path(), "/api/v1/users/123")
+        self.assertEqual(resource.make_path("edit"), "/api/v1/users/123/edit")
+
+    def test_resource_make_path_with_end_slash(self):
+        """Test that make_path respects end_slash parameter."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertTrue(resource.make_path(end_slash=True).endswith("/"))
+        self.assertFalse(resource.make_path(end_slash=False).endswith("/"))
+
+    def test_resource_make_url(self):
+        """Test that make_url constructs full URLs."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.make_url(), "https://audit.test/api/v1/users/123")
+        self.assertEqual(resource.make_url("edit"), "https://audit.test/api/v1/users/123/edit")
+
+    def test_resource_client_propagation(self):
+        """Test that client property returns parent's client."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.client, self.client)
+
+    def test_resource_with_explicit_client(self):
+        """Test that explicit client overrides parent's client."""
+        explicit_client = MockJsonClient("https://other.test")
+        resource = MockResource(
+            "123",
+            parent=self.collection,
+            root=self.root,
+            client=explicit_client
+        )
+
+        self.assertEqual(resource.client, explicit_client)
+
+    def test_resource_root_property(self):
+        """Test that root property returns the root resource."""
+        resource = MockResource("123", parent=self.collection, root=self.root)
+
+        self.assertEqual(resource.root, self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/audit/test_traces.py
+++ b/tests/unit/audit/test_traces.py
@@ -1,0 +1,277 @@
+"""Unit tests for campus.audit.client.v1.traces module.
+
+These tests verify that the Traces resource properly constructs API requests
+and follows Campus API schema conventions.
+
+Test Principles:
+- Test resource chaining and path construction
+- Test bracket access for IDs
+- Test property access for named sub-resources
+- Test HTTP method calls (mocked)
+"""
+
+import unittest
+from unittest.mock import Mock, MagicMock, call
+
+from campus.audit.client.v1.traces import Traces
+from campus.audit.client.v1.root import AuditRoot
+from campus.common.http.interface import JsonClient
+
+
+class TestTracesResource(unittest.TestCase):
+    """Test Traces resource collection."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = Mock(spec=JsonClient)
+        self.mock_client.base_url = "https://audit.test"
+        self.root = AuditRoot(json_client=self.mock_client)
+
+    def test_traces_path_has_trailing_slash(self):
+        """Test that Traces.path has trailing slash (ResourceCollection requirement)."""
+        self.assertTrue(Traces.path.endswith("/"))
+        self.assertEqual(Traces.path, "traces/")
+
+    def test_traces_make_path(self):
+        """Test that make_path constructs correct paths."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        # Base path
+        self.assertEqual(traces.make_path(), "/audit/v1/traces/")
+
+        # With sub-path
+        self.assertEqual(traces.make_path("search"), "/audit/v1/traces/search")
+
+    def test_traces_make_url(self):
+        """Test that make_url constructs full URLs."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        self.assertEqual(traces.make_url(), "https://audit.test/audit/v1/traces/")
+        self.assertEqual(traces.make_url("search"), "https://audit.test/audit/v1/traces/search")
+
+    def test_traces_getitem_returns_trace_resource(self):
+        """Test that bracket access creates Trace resource."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        trace = traces["abc123"]
+
+        # Verify it's a Trace resource
+        self.assertIsInstance(trace, Traces.Trace)
+        self.assertEqual(trace.trace_id, "abc123")
+        self.assertEqual(trace.parent, traces)
+
+    def test_traces_new_single_span(self):
+        """Test that new(span) calls POST with correct payload."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.post.return_value = mock_response
+
+        span = {"trace_id": "abc123", "span_id": "def456"}
+        result = traces.new(span)
+
+        # Verify POST was called correctly
+        self.mock_client.post.assert_called_once_with(
+            "/audit/v1/traces/",
+            json={"spans": [span]}
+        )
+        self.assertEqual(result, mock_response)
+
+    def test_traces_new_batch_spans(self):
+        """Test that new(s1, s2, s3) calls POST with all spans."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.post.return_value = mock_response
+
+        span1 = {"trace_id": "abc123", "span_id": "def456"}
+        span2 = {"trace_id": "abc123", "span_id": "ghi789"}
+        span3 = {"trace_id": "abc123", "span_id": "jkl012"}
+
+        result = traces.new(span1, span2, span3)
+
+        # Verify POST was called with all spans
+        self.mock_client.post.assert_called_once_with(
+            "/audit/v1/traces/",
+            json={"spans": [span1, span2, span3]}
+        )
+        self.assertEqual(result, mock_response)
+
+    def test_traces_list_with_defaults(self):
+        """Test that list() uses default parameters."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = traces.list()
+
+        # Verify GET was called with default limit
+        self.mock_client.get.assert_called_once_with(
+            "/audit/v1/traces/",
+            params={"limit": 50}
+        )
+        self.assertEqual(result, mock_response)
+
+    def test_traces_list_with_params(self):
+        """Test that list(limit=10, since=...) includes parameters."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = traces.list(limit=10, since="2025-01-01T00:00:00Z")
+
+        # Verify GET was called with parameters
+        self.mock_client.get.assert_called_once_with(
+            "/audit/v1/traces/",
+            params={"limit": 10, "since": "2025-01-01T00:00:00Z"}
+        )
+        self.assertEqual(result, mock_response)
+
+    def test_traces_search_with_filters(self):
+        """Test that search includes query parameters."""
+        traces = Traces(client=self.mock_client, root=self.root)
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = traces.search(path="/api/v1/users", status=200)
+
+        # Verify GET was called with search filters
+        self.mock_client.get.assert_called_once()
+        args, kwargs = self.mock_client.get.call_args
+        self.assertEqual(args[0], "/audit/v1/traces/search")
+        self.assertIn("path", kwargs["params"])
+        self.assertIn("status", kwargs["params"])
+        self.assertEqual(result, mock_response)
+
+
+class TestTraceResource(unittest.TestCase):
+    """Test Trace resource (individual trace by ID)."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = Mock(spec=JsonClient)
+        self.mock_client.base_url = "https://audit.test"
+        self.root = AuditRoot(json_client=self.mock_client)
+        self.traces = Traces(client=self.mock_client, root=self.root)
+
+    def test_trace_path_construction(self):
+        """Test that Trace path includes trace_id."""
+        trace = self.traces["abc123"]
+
+        self.assertEqual(trace.path, "/audit/v1/traces/abc123")
+        self.assertEqual(trace.make_path(end_slash=True), "/audit/v1/traces/abc123/")
+
+    def test_trace_get_tree(self):
+        """Test that get_tree() calls GET to correct endpoint."""
+        trace = self.traces["abc123"]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = trace.get_tree()
+
+        # Verify GET was called
+        self.mock_client.get.assert_called_once_with("/audit/v1/traces/abc123/")
+        self.assertEqual(result, mock_response)
+
+    def test_trace_spans_property_returns_spans_resource(self):
+        """Test that .spans property returns Spans resource."""
+        trace = self.traces["abc123"]
+
+        spans = trace.spans
+
+        # Verify it's a Spans resource
+        self.assertIsInstance(spans, Traces.Spans)
+        self.assertEqual(spans.trace_id, "abc123")
+        self.assertEqual(spans.parent, trace)
+
+
+class TestSpansResource(unittest.TestCase):
+    """Test Spans resource (nested within Trace)."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = Mock(spec=JsonClient)
+        self.mock_client.base_url = "https://audit.test"
+        self.root = AuditRoot(json_client=self.mock_client)
+        self.traces = Traces(client=self.mock_client, root=self.root)
+        self.trace = self.traces["abc123"]
+
+    def test_spans_path_construction(self):
+        """Test that Spans path includes 'spans/'."""
+        spans = self.trace.spans
+
+        self.assertEqual(spans.path, "spans/")
+        self.assertEqual(spans.make_path(), "/audit/v1/traces/abc123/spans/")
+
+    def test_spans_list(self):
+        """Test that list() calls GET to list spans."""
+        spans = self.trace.spans
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = spans.list()
+
+        # Verify GET was called
+        self.mock_client.get.assert_called_once_with("/audit/v1/traces/abc123/spans/")
+        self.assertEqual(result, mock_response)
+
+    def test_spans_getitem_returns_span_resource(self):
+        """Test that bracket access creates Span resource."""
+        spans = self.trace.spans
+
+        span = spans["def456"]
+
+        # Verify it's a Span resource
+        self.assertIsInstance(span, Traces.Spans.Span)
+        self.assertEqual(span.span_id, "def456")
+        self.assertEqual(span.parent, spans)
+
+
+class TestSpanResource(unittest.TestCase):
+    """Test Span resource (individual span within Spans)."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_client = Mock(spec=JsonClient)
+        self.mock_client.base_url = "https://audit.test"
+        self.root = AuditRoot(json_client=self.mock_client)
+        self.traces = Traces(client=self.mock_client, root=self.root)
+        self.trace = self.traces["abc123"]
+        self.spans = self.trace.spans
+
+    def test_span_path_construction(self):
+        """Test that Span path includes span_id."""
+        span = self.spans["def456"]
+
+        self.assertEqual(span.path, "/audit/v1/traces/abc123/spans/def456")
+        self.assertEqual(span.make_path(end_slash=True), "/audit/v1/traces/abc123/spans/def456/")
+
+    def test_span_get(self):
+        """Test that get() calls GET to correct endpoint."""
+        span = self.spans["def456"]
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        self.mock_client.get.return_value = mock_response
+
+        result = span.get()
+
+        # Verify GET was called
+        self.mock_client.get.assert_called_once_with("/audit/v1/traces/abc123/spans/def456/")
+        self.assertEqual(result, mock_response)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

Adds an internal HTTP client for the Campus audit service that follows Campus API schema conventions. This client enables `campus.auth` and `campus.api` deployments to send trace spans to `campus.audit` via HTTP.

## Changes

### Client Implementation
- `campus/audit/client/__init__.py` - `AuditClient` entry point with environment-based URL resolution
- `campus/audit/client/interface.py` - `ResourceRoot`, `ResourceCollection`, `Resource` base classes
- `campus/audit/client/v1/__init__.py` - v1 API module
- `campus/audit/client/v1/root.py` - `AuditRoot` resource
- `campus/audit/client/v1/traces.py` - `Traces`, `Trace`, `Spans`, `Span` resources with nested class structure

### Unit Tests
- `tests/unit/audit/test_client.py` - Client initialization tests
- `tests/unit/audit/test_interface.py` - Base resource class tests
- `tests/unit/audit/test_traces.py` - Traces resource tests

## API Usage

```python
from campus.audit.client import AuditClient

client = AuditClient()

# Ingest spans
client.traces.new(span_data)           # Single
client.traces.new(s1, s2, s3)          # Batch

# List/search traces
client.traces.list(limit=10)
client.traces.search(path="/api/v1/users")

# Get trace tree
tree = client.traces[trace_id].get_tree()

# Get span
span = client.traces[trace_id].spans[span_id].get()
```

## Design

Follows `campus-api-python` structure with:
- `ResourceCollection` for collections
- Nested classes for individual items
- Standard verbs: `new()`, `list()`, `search()`, `get()`
- Bracket access for IDs: `client.traces[trace_id]`
- Property access for named sub-resources: `client.traces[trace_id].spans`

## Related Issues

- Resolves #453
- Part of: #428 (Phase 4: Tracing Middleware)