### PR TITLE
feat(auth): register tracing middleware

### DIFF
--- a/campus/auth/__init__.py
+++ b/campus/auth/__init__.py
@@ -70,3 +70,9 @@ def init_app(app: flask.Blueprint | flask.Flask) -> None:
     # causing confusing 401 errors on authenticated endpoints.
     if isinstance(app, flask.Flask):
         app.url_map.strict_slashes = True
+
+    # Register tracing middleware (captures all requests)
+    if isinstance(app, flask.Flask):
+        from campus.audit.middleware import tracing
+        app.before_request(tracing.start_span)
+        app.after_request(tracing.end_span)


### PR DESCRIPTION
## Overview

Registers the audit tracing middleware in campus.auth to capture all HTTP requests as trace spans.

## Changes

- **campus/auth/__init__.py**: Register tracing middleware hooks
  - `before_request(start_span)`: Generates trace_id and span_id, stores in flask.g
  - `after_request(end_span)`: Records duration, builds span, ingests to audit service

## Behavior

The middleware now captures:
- Request metadata (method, path, headers, query string)
- Response metadata (status, headers, body truncated to 64KB)
- Duration in milliseconds
- Trace/span IDs for correlation

**Authorization headers are stripped** before ingestion for security.

**Async ingestion** via ThreadPoolExecutor avoids blocking request handling.

**Graceful degradation**: If audit service is unreachable, spans are dropped but requests continue normally.

## Testing

- Unit tests: 204 passed
- Integration tests: 30 passed
- Middleware warnings in logs confirm it's attempting to ingest spans

## Related Issues

- Part of: #428 (Phase 4: Tracing Middleware)
- Depends on: #453 (Internal audit client)