### PR TITLE
fix: use env.get() instead of attribute access

### DIFF
--- a/campus/common/devops/deploy.py
+++ b/campus/common/devops/deploy.py
@@ -30,7 +30,10 @@ class AppModule(Protocol):
 
 def is_codespace() -> bool:
     """Check if running in a GitHub Codespace environment."""
-    return env.CODESPACES is not None and env.CODESPACES.lower() == "true"
+    return (
+        env.get("CODESPACES") is not None
+        and env.CODESPACES.lower() == "true"
+    )
 
 
 def configure_for_codespace(app: flask.Flask) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "campus-suite"
-version = "0.1.14"
+version = "0.1.15"
 description = "Campus Suite - Complete education management platform deployment orchestrator and client library"
 authors = ["Ng Jun Siang <ngjunsiang@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes a bug where `campus.common.deploy.is_codespace()` causes a crash in a non-codespace.