### PR TITLE
fix: resolve race condition in credentials resource (#461)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true
+  }
+}

--- a/campus/auth/provider.py
+++ b/campus/auth/provider.py
@@ -283,11 +283,6 @@ def token(
                 * utc_time.DAY_SECONDS
             ),
         )
-        # Update credentials with the new token
-        user_credentials_resource.update(
-            client_id=authsession.client_id,
-            token=token
-        )
     return token.to_resource(), 200
 
 

--- a/campus/auth/resources/credentials.py
+++ b/campus/auth/resources/credentials.py
@@ -188,6 +188,7 @@ class UserCredentialsResource:
         records = cred_storage.get_matching({
             "provider": self.parent.provider,
             "user_id": str(self.user_id),
+            "client_id": client_id,
         })
         if records:  # Existing credentials
             cred_storage.update_by_id(


### PR DESCRIPTION
## Summary
Fixes #461

- Add `client_id` to query in `UserCredentialsResource.new()` to ensure correct credential is updated for user-client pairs
- Remove redundant `update()` call in `provider.py` token endpoint that was causing duplicate insert race conditions

The `new()` method already inserts the credential record, so the subsequent `update()` call was redundant and caused transient duplicate key errors during concurrent logins.

## Test plan
- [ ] Test concurrent logins for same user across different clients
- [ ] Verify no duplicate key violations in logs
- [ ] Confirm correct token assignment per user-client pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)