### PR TITLE
fix: handle missing credentials gracefully in tracing middleware during cleanup

### DIFF
--- a/campus/audit/middleware/tracing.py
+++ b/campus/audit/middleware/tracing.py
@@ -4,7 +4,6 @@ Tracing middleware implementation for capturing HTTP request-response spans.
 """
 
 import concurrent.futures
-import copy
 import json
 import logging
 import time
@@ -37,12 +36,26 @@ def _get_audit_client() -> AuditClient:
 
     Returns:
         AuditClient instance for sending spans to audit service.
+
+    Raises:
+        ValueError: If CLIENT_ID or CLIENT_SECRET are not set in environment.
     """
     global _audit_client, _client_credentials
 
     # Get current credentials from environment
     from campus.common import env
-    current_credentials = (env.CLIENT_ID, env.CLIENT_SECRET)
+
+    # Check if credentials are available (they may be deleted during test cleanup)
+    client_id = env.get("CLIENT_ID")
+    client_secret = env.get("CLIENT_SECRET")
+
+    if not client_id or not client_secret:
+        raise ValueError(
+            "CLIENT_ID and CLIENT_SECRET must be set in environment "
+            "to create audit client"
+        )
+
+    current_credentials = (client_id, client_secret)
 
     # Recreate client if credentials have changed or client doesn't exist
     if _audit_client is None or _client_credentials != current_credentials:
@@ -278,6 +291,10 @@ def _ingest_span_async(span: dict) -> None:
         try:
             client = _get_audit_client()
             client.traces.new(span)
+        except ValueError as e:
+            # Credentials not available (e.g., during test cleanup)
+            # This is expected during shutdown, so log at debug level
+            logger.debug(f"Skipping trace ingestion: {e}")
         except Exception as e:
             # Don't let tracing errors break the application
             logger.warning(f"Failed to ingest trace span: {e}")

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -226,6 +226,16 @@ class ServiceManager:
         Always cleans up auth client and credentials. With shared=False,
         also cleans up Flask apps for full isolation.
         """
+        # Shut down tracing middleware's background thread pool FIRST
+        # This must happen BEFORE clearing credentials and storage to avoid
+        # race conditions where background threads try to access cleared resources
+        try:
+            from campus.audit.middleware import tracing
+            tracing._ingestion_executor.shutdown(wait=True)
+        except Exception:
+            # If tracing module isn't loaded or executor already shut down, continue
+            pass
+
         # Always clean up auth client regardless of shared mode
         self._cleanup_auth_client()
 
@@ -234,10 +244,6 @@ class ServiceManager:
             env.delete("CLIENT_ID")
         if env.contains("CLIENT_SECRET"):
             env.delete("CLIENT_SECRET")
-
-        # Clean up audit client factory
-        from campus.audit.client import set_http_client_factory
-        set_http_client_factory(None)  # Reset to None
 
         # Clean up audit client factory
         from campus.audit.client import set_http_client_factory


### PR DESCRIPTION
## Summary
- Fix race condition where tracing middleware's background threads try to access CLIENT_ID/CLIENT_SECRET after test cleanup deletes them
- Use `env.get()` instead of attribute access to check credential availability
- Log credential errors at debug level (expected during shutdown) instead of warning
- Remove unused 'copy' import

## Problem
During integration test cleanup, the tracing middleware's background threads would fail with confusing error messages like `"module 'campus.common.env' has no attribute 'CLIENT_ID'"` when trying to send traces after `ServiceManager.close()` deleted the credentials.

## Solution
- Check credential availability using `env.get()` before accessing
- Raise clear `ValueError` when credentials are missing
- Catch `ValueError` in the async ingestion handler and log at debug level (expected during shutdown)
- This eliminates confusing error messages while maintaining proper error handling

## Test plan
- [x] Integration tests pass: `poetry run python tests/run_tests.py integration`
- [x] Verified old error message is eliminated
- [x] Tests still pass with proper error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)