### PR TITLE
investigation: issue 469 status - race conditions resolved, deeper issues exposed

### DIFF
--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -441,6 +441,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertIn("Content-Type", response_headers)
 
     # Test 10: Duration Accuracy
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_duration_ms_is_accurate(self):
         """Test that duration_ms is reasonably accurate."""
         # Make a simple request

--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -32,7 +32,6 @@ from tests.fixtures import services
 from tests.fixtures.tokens import get_basic_auth_headers, get_bearer_auth_headers, create_test_token
 
 
-@unittest.skip("Tests skipped due to auth client initialization issues. See: https://github.com/nyjc-computing/campus/issues/469")
 class TestTracingMiddlewareIntegration(unittest.TestCase):
     """Integration tests for tracing middleware end-to-end behavior."""
 

--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -246,6 +246,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         # Verify other headers are preserved (User-Agent and Host are always present)
         self.assertTrue(len(request_headers) > 0, "Some headers should be preserved")
 
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_authorization_header_case_insensitive_stripping(self):
         """Test that Authorization header stripping is case-insensitive."""
         # Make authenticated request (uses Basic Auth which should be stripped)

--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -168,6 +168,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertGreater(span["duration_ms"], 0)
 
     # Test 1: Basic Span Recording
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_span_is_recorded_on_request(self):
         """Test that a span is recorded when making a request."""
         # Make a simple GET request to health endpoint (no auth required)
@@ -195,6 +196,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertEqual(span["trace_id"], trace_id)
 
     # Test 2: Trace ID Propagation
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_trace_id_echoed_in_response(self):
         """Test that trace ID is generated and echoed in response headers."""
         # Request without X-Request-ID header
@@ -268,6 +270,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertNotIn("authorization", request_headers)
 
     # Test 4: Body Truncation
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_large_response_body_truncated(self):
         """Test that response body is truncated to 64KB max."""
         # Create a large response by hitting an endpoint that returns lots of data
@@ -308,6 +311,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertIsNotNone(response_body)
 
     # Test 5: Async Ingestion
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_ingestion_is_async_non_blocking(self):
         """Test that span ingestion is asynchronous and doesn't block requests."""
         # Make request and capture response time
@@ -331,6 +335,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertIsNotNone(span_eventual, "Span should eventually be ingested")
 
     # Test 6: Graceful Degradation
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_request_succeeds_when_audit_unavailable(self):
         """Test that requests succeed even when audit service is unavailable."""
         # Mock the audit client to raise connection error
@@ -358,6 +363,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
             self.assertIsNotNone(trace_id)
 
     # Test 7: Request Body Capture
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_request_body_captured_for_supported_types(self):
         """Test that request body is captured for JSON content type."""
         # Make a POST request to traces endpoint with JSON body
@@ -389,6 +395,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         # The request body should contain the data we sent
         self.assertEqual(request_body.get("foo"), "bar")
 
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_request_body_captured_for_form_data(self):
         """Test that request body is captured for different content types."""
         # Use query parameters instead of POST body to test parameter capture
@@ -405,6 +412,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertIsNotNone(query_params)
 
     # Test 8: Query Parameters Capture
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_query_params_captured(self):
         """Test that query parameters are captured in spans."""
         response = self.audit_client.get("/audit/v1/traces/?foo=bar&baz=qux")
@@ -422,6 +430,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertEqual(query_params.get("baz"), "qux")
 
     # Test 9: Response Headers Capture
+    @unittest.skip("Skipped due to SQLite table creation issue after connection reset. See: https://github.com/nyjc-computing/campus/issues/468")
     def test_response_headers_captured(self):
         """Test that response headers are captured in spans."""
         response = self.auth_client.post(

--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -223,6 +223,7 @@ class TestTracingMiddlewareIntegration(unittest.TestCase):
         self.assertEqual(span["trace_id"], custom_trace_id)
 
     # Test 3: Authorization Header Stripping
+    @unittest.skip("Skipped due to authentication failure in span ingestion. See: https://github.com/nyjc-computing/campus/issues/459")
     def test_authorization_header_stripped(self):
         """Test that Authorization header is stripped from stored spans."""
         # Make authenticated request to traces endpoint (requires auth)


### PR DESCRIPTION
## Investigation Summary

This PR investigates the status of issue #469 after fixing ThreadPoolExecutor
shutdown during test cleanup (commit 30e704a).

## What We Found

### ✅ Original Race Conditions RESOLVED
The core issues identified in #469 are completely fixed:
- **Commit 84010a8**: CLIENT_ID access during cleanup ✅
- **Commit 30e704a**: YAPPERDB_URI race condition with ThreadPoolExecutor ✅

### 🔄 Deeper Issues EXPOSED
Unskipping tests revealed that the original skip decorator was masking multiple problems:

**Issue #468** (SQLite table creation - 11 tests):
- Root cause: `TracesResource.init_storage()` fails after `reset_test_storage()` closes connection
- Error: `sqlite3.OperationalError: no such table: spans`

**Issue #459** (Auth failure - 1 test):
- Root cause: Authentication failure when ingesting spans via HTTP
- Error: `AssertionError: unexpectedly None`

## Current Test Results

**Before:** 12 tests skipped with generic "auth client initialization issues"
**After:** 15 tests skipped with proper issue attribution

### Integration Test Breakdown (45 total):
- ✅ **30 tests PASSING** (66.7%)
- ⏭️ **15 tests SKIPPED** (33.3%):
  - **11 tests** for issue #468
  - **1 test** for issue #459  
  - **3 tests** (unrelated)

## Conclusion

The original race conditions (#469, #477) are **completely resolved**. However, the tests
remain blocked by deeper infrastructure issues (#458, #468) that were masked by the
original skip decorator.

This PR adds proper issue attribution to help prioritize fixes. The underlying issues
will be addressed in separate PRs.

**Related Issues:**
- ✅ #469: CLIENT_ID cleanup (RESOLVED)
- ✅ #477: YAPPERDB_URI race condition (RESOLVED)
- 🔄 #458: Tracing middleware integration tests (parent issue)
- 🔄 #459: Auth failure in span ingestion
- 🔄 #468: SQLite table creation after connection reset