### PR TITLE
fix: resolve issue #496 - first test timing issue in TestTracingMiddlewareSpanIngestion

### DIFF
--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -240,6 +240,14 @@ class TestTracingMiddlewareSpanIngestion(DependencyCheckedTestCase):
         # executor ensures clean state for this dependency check.
         from campus.audit.middleware import tracing
         original_executor = tracing._ingestion_executor
+
+        # CRITICAL: Wait for the original executor to finish all pending tasks
+        # before replacing it. This prevents issue #496 where pending tasks from
+        # the previous test class are still processing when we create the fresh
+        # executor, causing those tasks to fail when the original executor is
+        # restored and shut down.
+        original_executor.shutdown(wait=True)
+
         tracing._ingestion_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="dependency_check_ingest"
         )
@@ -293,8 +301,17 @@ class TestTracingMiddlewareSpanIngestion(DependencyCheckedTestCase):
 
         finally:
             # Clean up the temporary executor
+            # Use wait=True to ensure all pending tasks complete before shutdown
+            # This prevents issue #496 where spans fail to ingest with
+            # "cannot schedule new futures after shutdown" error
             tracing._ingestion_executor.shutdown(wait=True)
-            tracing._ingestion_executor = original_executor
+
+            # CRITICAL: Recreate the original executor instead of restoring the
+            # shut-down executor. We already shut down the original executor
+            # before creating the fresh one, so we need to recreate it here.
+            tracing._ingestion_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=2, thread_name_prefix="audit_ingest"
+            )
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
Fixed the timing issue where `test_authorization_header_stripped` (the first test alphabetically in `TestTracingMiddlewareSpanIngestion`) consistently failed due to async span ingestion not completing.

## Root Cause
- The dependency check created a fresh executor and restored the original executor
- The original executor had pending tasks from the previous test class
- When the fresh executor was shut down and the original restored, pending tasks failed with "cannot schedule new futures after shutdown"

## Solution
Modified `_check_dependencies()` in `tests/integration/test_audit_tracing_middleware.py`:
- Shut down the original executor before creating the fresh executor (ensures all pending tasks from previous test class complete)
- Recreate the executor after dependency check instead of restoring the shut-down one

## Changes
- Line 242-244: Added `original_executor.shutdown(wait=True)` before creating fresh executor
- Line 299-302: Modified finally block to recreate executor instead of restoring original

## Testing
- ✅ All 31 integration tests pass
- ✅ `test_authorization_header_stripped` passes consistently (verified 3 runs)
- ✅ No timing issues or race conditions

## Impact
- Fixes issue #496
- Improves test reliability and CI/CD stability
- No breaking changes

Fixes #496