### PR TITLE
fix: correct vault label in test fixtures from 'yapper' to 'campus.yapper'

### DIFF
--- a/tests/fixtures/yapper.py
+++ b/tests/fixtures/yapper.py
@@ -38,10 +38,10 @@ def init():
 
     # Give test client access to vault
     client_resource = auth_resources.client[client_id]
-    client_resource.access.grant("yapper", ClientAccess.ALL)
+    client_resource.access.grant("campus.yapper", ClientAccess.ALL)
 
     # Set up vault with database URI as a secret
-    yapper_vault = auth_resources.vault["yapper"]
+    yapper_vault = auth_resources.vault["campus.yapper"]
 
     # Check if already initialized (idempotent)
     if _yapper_db_path is not None:


### PR DESCRIPTION
## Summary
- Fix vault label mismatch in test fixtures causing sanity check failures
- Change `vault["yapper"]` to `vault["campus.yapper"]` in tests/fixtures/yapper.py
- Aligns test fixture configuration with production code expectations

## Root Cause
The yapper module expects vault label `'campus.yapper'` but test fixtures were using `'yapper'`, causing `KeyError: 'YAPPERDB_URI' not found in 'campus.yapper'` when sanity tests tried to create Flask apps.

## Test Plan
- ✅ All 21 sanity checks pass (verified in pre-push hook)
- ✅ Tests remain local (no external service dependencies)
- ✅ Vault label now matches production code expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)