### PR TITLE
fix: correct vault label in yapper integration test

### DIFF
--- a/tests/integration/yapper/test_yapper.py
+++ b/tests/integration/yapper/test_yapper.py
@@ -36,7 +36,7 @@ class TestYapper(IntegrationTestCase):
         encoded = base64.b64encode(credentials.encode()).decode()
         headers = {"Authorization": f"Basic {encoded}"}
 
-        response = self.client.get("/auth/v1/vaults/yapper/YAPPERDB_URI", headers=headers)
+        response = self.client.get("/auth/v1/vaults/campus.yapper/YAPPERDB_URI", headers=headers)
 
         # Should get a successful response with the YAPPERDB_URI value
         self.assertEqual(response.status_code, 200,


### PR DESCRIPTION
## Summary
- Fixed `test_yapper_vault_access` to use correct vault label `"campus.yapper"` instead of `"yapper"`
- Resolves 404 "Key not found" error in integration tests

## Details
The vault routes expect the full label including the service prefix, not just the service name. The test was accessing:
- **Incorrect:** `/auth/v1/vaults/yapper/YAPPERDB_URI`  
- **Correct:** `/auth/v1/vaults/campus.yapper/YAPPERDB_URI`

## Test plan
- [x] All 32 integration tests now pass
- [x] Sanity checks passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)