### PR TITLE
refactor(tests): low-hanging fruit for integration test lifecycle (fixes 1-3 from #518)

### DIFF
--- a/campus/storage/documents/backend/memory.py
+++ b/campus/storage/documents/backend/memory.py
@@ -264,3 +264,14 @@ class MemoryCollection(CollectionInterface):
     def reset_storage(cls):
         """Reset the in-memory storage. Useful for testing."""
         cls._storage.clear()
+
+    @classmethod
+    def clear_storage(cls):
+        """Clear all documents from all collections while preserving collection structure.
+
+        This is faster than reset_storage() for per-test cleanup since it
+        doesn't require recreating collections. Useful for test isolation.
+        """
+        # Clear all documents from each collection
+        for collection_name in cls._storage:
+            cls._storage[collection_name].clear()

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -458,3 +458,24 @@ class SQLiteTable(TableInterface):
         if cls._connection:
             cls._connection.close()
             cls._connection = None
+
+    @classmethod
+    def clear_database(cls):
+        """Clear all data from all tables while preserving table structure.
+
+        This is faster than reset_database() for per-test cleanup since it
+        doesn't require recreating tables. Useful for test isolation.
+        """
+        if cls._connection is None:
+            return  # No database to clear
+
+        cursor = cls._connection.cursor()
+        # Get all table names
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cursor.fetchall()]
+
+        # Delete all rows from each table
+        for table in tables:
+            cursor.execute(f'DELETE FROM "{table}"')
+
+        cls._connection.commit()

--- a/campus/storage/testing.py
+++ b/campus/storage/testing.py
@@ -59,3 +59,20 @@ def reset_test_storage():
 
         SQLiteTable.reset_database()
         MemoryCollection.reset_storage()
+
+
+def clear_all_data():
+    """Clear all data from test storage while preserving table/collection structure.
+
+    This is faster than reset_test_storage() for per-test cleanup since it
+    doesn't require recreating tables and collections. Only works in test mode.
+
+    Use this in setUp() for per-test isolation when you want to clear data
+    but preserve the schema defined in setUpClass().
+    """
+    if is_test_mode():
+        from campus.storage.tables.backend.sqlite import SQLiteTable
+        from campus.storage.documents.backend.memory import MemoryCollection
+
+        SQLiteTable.clear_database()
+        MemoryCollection.clear_storage()

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -292,6 +292,10 @@ class ServiceManager:
         """Clean up shared service instances and reset storage.
 
         Should be called at the end of test runs to ensure clean state.
+
+        Note: Does not call reset_test_storage() here to avoid redundant cleanup.
+        The close() method already handles cleanup, and any subsequent test runs
+        will reset storage in their setup() calls.
         """
         # Unpatch campus_python and clear test apps
         from tests import flask_test
@@ -308,10 +312,6 @@ class ServiceManager:
             env.delete("CLIENT_ID")
         if env.contains("CLIENT_SECRET"):
             env.delete("CLIENT_SECRET")
-
-        # Reset test storage
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def __enter__(self):
         """Context manager entry."""

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -90,11 +90,13 @@ class IntegrationTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        """Clean up service manager and reset test storage."""
+        """Clean up service manager.
+
+        Note: Does not call reset_test_storage() here to avoid redundant cleanup.
+        The next test class will reset storage in its setup() method.
+        """
         if hasattr(cls, 'service_manager'):
             cls.service_manager.close()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
 
 class IsolatedIntegrationTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR implements fixes 1-3 from issue #518 to reduce redundant cleanup in integration test infrastructure, moving toward the ideal state described in the proposal.

## Changes

### Fix 1: Remove redundant `reset_test_storage()` in `IntegrationTestCase.tearDownClass()`
- **File:** `tests/integration/base.py`
- **Impact:** Eliminates redundant storage reset that was happening 3 times between test classes
- **Commit:** `076d6e6`

### Fix 2: Remove redundant `reset_test_storage()` in `cleanup_shared()`
- **File:** `tests/fixtures/services.py`
- **Impact:** Removes duplicate cleanup after `close()` already handled it
- **Commit:** `fd3aa70`

### Fix 3: Add `clear_all_data()` method to `campus.storage.testing`
- **Files:** 
  - `campus/storage/testing.py`
  - `campus/storage/tables/backend/sqlite.py`
  - `campus/storage/documents/backend/memory.py`
- **Impact:** Provides faster per-test cleanup that preserves table/collection structure
- **Commit:** `853dc7d`

## Benefits

- **Less redundant cleanup** - Storage reset now happens once per test class instead of 3 times
- **Clearer ownership** - Single responsibility for storage reset in `ServiceManager.setup()`
- **Faster tests** - New `clear_all_data()` enables future optimizations
- **Path to ideal state** - These changes make the eventual full refactor easier

## Test Results

✅ Integration tests: 32 passed  
✅ Unit tests: 221 passed  
✅ Sanity tests: 21 passed

## Out of Scope

Fix 5 (executor idempotency) was attempted but proved not to be low-hanging fruit. A separate issue (#520) has been created with detailed findings and proposed solutions for future consideration.

Fixes 4 & 6 (documentation improvements) will be tackled in a separate PR as requested.

## Related Issues

- Closes #518 (partial - fixes 1-3 only)
- #520: Design proposal for cleaner executor idempotency