### PR TITLE
refactor(tests): migrate sanity tests to new ServiceManager API (#525)

### DIFF
--- a/tests/sanity/test_api_deployment.py
+++ b/tests/sanity/test_api_deployment.py
@@ -32,13 +32,13 @@ class TestAPIDeployment(unittest.TestCase):
     def setUpClass(cls):
         """Set up test services for deployment tests."""
         cls.service_manager = services.create_service_manager()
-        cls.service_manager.setup()
+        cls.service_manager.initialize()
 
     @classmethod
     def tearDownClass(cls):
         """Clean up test services."""
         if hasattr(cls, 'service_manager'):
-            cls.service_manager.close()
+            cls.service_manager.cleanup()
 
         # Reset test storage to clear SQLite in-memory database
         import campus.storage.testing

--- a/tests/sanity/test_auth_deployment.py
+++ b/tests/sanity/test_auth_deployment.py
@@ -30,13 +30,13 @@ class TestAuthDeployment(unittest.TestCase):
     def setUpClass(cls):
         """Set up test services for deployment tests."""
         cls.service_manager = services.create_service_manager()
-        cls.service_manager.setup()
+        cls.service_manager.initialize()
 
     @classmethod
     def tearDownClass(cls):
         """Clean up test services."""
         if hasattr(cls, 'service_manager'):
-            cls.service_manager.close()
+            cls.service_manager.cleanup()
 
         # Reset test storage to clear SQLite in-memory database
         import campus.storage.testing

--- a/tests/sanity/test_wsgi.py
+++ b/tests/sanity/test_wsgi.py
@@ -22,7 +22,7 @@ class TestWSGI(unittest.TestCase):
     def setUpClass(cls):
         """Set up local services once for the entire test class."""
         cls.service_manager = services.create_service_manager()
-        cls.service_manager.setup()
+        cls.service_manager.initialize()
         # Save original environment
         cls._original_env = dict(os.environ)
 
@@ -30,7 +30,7 @@ class TestWSGI(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up services after all tests in the class."""
         if hasattr(cls, 'service_manager'):
-            cls.service_manager.close()
+            cls.service_manager.cleanup()
 
         # Reset test storage to clear SQLite in-memory database
         import campus.storage.testing


### PR DESCRIPTION
## Summary
Phase 1 of issue #525: Migrate sanity tests from deprecated ServiceManager lifecycle methods to new API.

## Changes
- **test_wsgi.py**: `setup()` → `initialize()`, `close()` → `cleanup()`
- **test_api_deployment.py**: `setup()` → `initialize()`, `close()` → `cleanup()`
- **test_auth_deployment.py**: `setup()` → `initialize()`, `close()` → `cleanup()`

## Testing
✅ All 21 sanity tests pass successfully with the new API (0.881s)

## Benefits
- Consistency: All sanity tests now use the same ServiceManager API as integration tests
- Cleaner: Eliminates deprecation warnings in test output
- Maintainability: Follows current best practices for ServiceManager lifecycle

## Related Issues
- Partially addresses #525 (Phase 1: Sanity tests complete)

## Test plan
- [x] All sanity tests pass
- [x] No deprecation warnings in test output
- [ ] Phase 2: Contract tests migration (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)