### PR TITLE
Refactor contract tests and fix audit authentication bug

### DIFF
--- a/campus/audit/__init__.py
+++ b/campus/audit/__init__.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 import flask
 
 from campus.common import webauth
-from campus.common.errors import auth_errors
+from campus.common.errors import auth_errors, api_errors
 from campus.common.utils import secret
 
 from . import resources
@@ -28,29 +28,35 @@ def _authenticate_audit_api_key() -> None:
     Sets flask.g.api_key_id for tracing middleware.
 
     Raises:
-        UnauthorizedClientError: if API key is invalid
+        UnauthorizedError: if API key is invalid or missing
 
     """
-    httpauth = webauth.http.HttpAuthenticationScheme.with_header(
-        provider="campus",
-        http_header=dict(flask.request.headers)
-    )
+    try:
+        httpauth = webauth.http.HttpAuthenticationScheme.with_header(
+            provider="campus",
+            http_header=dict(flask.request.headers)
+        )
+    except auth_errors.AuthorizationError:
+        # No Authorization header present - raise proper error for 401 response
+        raise api_errors.UnauthorizedError("Missing API key")
+
     # Extract API key from Bearer token
     api_key = httpauth.token
     # Validate format
     if not secret.is_valid_audit_api_key_format(api_key):
-        raise auth_errors.UnauthorizedClientError(
+        raise api_errors.UnauthorizedError(
             f"Invalid API key format. Expected: audit_v1_<22-char-base64url>"
         )
     api_key_id = resources.apikeys.verify(api_key)
     if not api_key_id:
-        raise auth_errors.UnauthorizedClientError("Invalid API key")
+        raise api_errors.UnauthorizedError("Invalid API key")
     flask.g.api_key_id = api_key_id
 
 
 def init_app(app: flask.Flask | flask.Blueprint) -> None:
     """Initialise the audit blueprint with the given Flask app."""
     from . import routes, web
+    from campus.common.errors import handlers
 
     # Organise audit routes under audit blueprint
     bp = flask.Blueprint('audit_v1', __name__, url_prefix='/audit/v1')
@@ -83,6 +89,8 @@ def init_app(app: flask.Flask | flask.Blueprint) -> None:
     app.register_blueprint(ui_blueprint)
 
     if isinstance(app, flask.Flask):
+        # Register error handlers for proper error responses
+        handlers.init_app(app)
         # Lazy import to allow env setup
         from campus.common import env
         app.secret_key = env.getsecret("SECRET_KEY")

--- a/campus/audit/__init__.py
+++ b/campus/audit/__init__.py
@@ -42,7 +42,7 @@ def _authenticate_audit_api_key() -> None:
         raise auth_errors.UnauthorizedClientError(
             f"Invalid API key format. Expected: audit_v1_<22-char-base64url>"
         )
-    api_key_id = resources.apikeys[api_key].verify(api_key)
+    api_key_id = resources.apikeys.verify(api_key)
     if not api_key_id:
         raise auth_errors.UnauthorizedClientError("Invalid API key")
     flask.g.api_key_id = api_key_id

--- a/campus/audit/resources/apikeys.py
+++ b/campus/audit/resources/apikeys.py
@@ -111,6 +111,41 @@ class APIKeysResource:
         else:
             return api_key, apikey_value
 
+    def verify(self, api_key: str) -> schema.CampusID | None:
+        """Verify if the provided API key is valid and return its ID.
+
+        This method scans all API keys to find a matching hash, since
+        requests contain the API key value, not the ID.
+
+        Args:
+            api_key: The plaintext API key to verify
+
+        Returns:
+            The ID of the API key if valid and active, None otherwise
+        """
+        api_key_hash = secret.hash_api_key(api_key)
+
+        # Query for active (non-revoked) API keys with matching hash
+        query = {
+            "key_hash": api_key_hash,
+            "revoked_at": None
+        }
+
+        try:
+            results = apikeys_storage.get_matching(query, limit=1)
+            if results:
+                key_record = model.APIKey.from_storage(results[0])
+                # Update last_used timestamp for audit trail
+                apikeys_storage.update_by_id(
+                    key_record.id,
+                    {"last_used": schema.DateTime.utcnow()}
+                )
+                return key_record.id
+        except (storage_errors.NotFoundError, IndexError):
+            pass
+
+        return None
+
 
 class APIKeyResource:
     """Represents a single API key resource."""
@@ -189,24 +224,3 @@ class APIKeyResource:
                 f"API key {self.api_key_id} not found"
             ) from None
         # TODO: audit campus.apikeys.update
-
-    def verify(self, api_key: str) -> schema.CampusID | None:
-        """Verify if the provided API key matches this resource.
-        API key ID is returned for purposes of audit.
-
-        Args:
-            api_key: The plaintext API key to verify
-
-        Returns:
-            The id of the API key if it matches, None otherwise
-        """
-        this_api_key = self.get()
-        if not this_api_key:
-            return None
-        # TODO: audit campus.apikeys.verify
-        # Audit is manually invoked here since there is no API endpoint
-        self.update(last_used=schema.DateTime.utcnow())
-        api_key_hash = secret.hash_api_key(api_key)
-        if api_key_hash == this_api_key.key_hash:
-            return this_api_key.id
-        return None


### PR DESCRIPTION
## Summary
- Reorganized contract tests into service-based subdirectories (api/, auth/, audit/)
- Fixed critical authentication bug in audit service causing all audit contract tests to fail
- Refactored audit API key verification to use collection-level lookup

## Changes

### Contract Tests Reorganization
- **[tests/contract/api/](tests/contract/api/)**: API endpoint contract tests (assignments, circles, emailotp, submissions)
- **[tests/contract/auth/](tests/contract/auth/)**: Auth service contract tests (clients, credentials, logins, sessions, users, vault)
- **[tests/contract/audit/](tests/contract/audit/)**: Audit contract tests (apikeys, traces)
- Updated [README.md](tests/contract/README.md) with new structure and test running commands

### Audit Service Bug Fixes
- **Root cause**: Authentication middleware was not handling missing Authorization headers properly
- **Moved verify() method**: From `APIKeyResource` to `APIKeysResource` since requests contain API keys (not IDs)
- **Fixed authentication**: Added try-except to catch missing Authorization headers and return proper 401 responses
- **Error handling**: Changed from `UnauthorizedClientError` (400) to `UnauthorizedError` (401)
- **Error handlers**: Registered proper error handlers in audit service

## Technical Details

### Authentication Bug
The audit service was trying to use the plaintext API key as an ID to look up resources:
```python
# BROKEN: Tried to use API key value as ID
api_key_id = resources.apikeys[api_key].verify(api_key)
```

Fixed by:
1. Moving `verify()` to collection level where it can scan for matching hashes
2. Adding proper error handling for missing Authorization headers
3. Registering error handlers to convert exceptions to HTTP responses

### Benefits
- Improved test organization and maintainability
- Easier to run targeted test suites for specific services
- Consistent with integration test structure
- Fixed authentication crash that prevented all audit tests from running

## Test plan
- [x] Contract tests reorganized into subdirectories
- [x] All contract tests remain discoverable and runnable
- [x] Authentication middleware no longer crashes on missing headers
- [x] Proper 401 responses returned instead of unhandled exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)