### PR TITLE
Fix Union type handling in SQLite and PostgreSQL backends

### DIFF
--- a/campus/storage/tables/backend/postgres.py
+++ b/campus/storage/tables/backend/postgres.py
@@ -89,12 +89,54 @@ def _validate_field_metadata(field: dataclasses.Field) -> None:
                 )
 
 
+def _get_base_type(field_type):
+    """Get the base Python type for a field type.
+
+    Returns one of: bool, int, float, str (or str as default if not recognized).
+    Handles both built-in types, schema types (which are subclasses),
+    and Union/Optional types (e.g., int | None, Optional[int]).
+    """
+    import types
+    import typing
+
+    # Handle Union/Optional types (e.g., int | None, Optional[int])
+    # Check for both typing.Union (old syntax) and types.UnionType (Python 3.10+ syntax)
+    origin = typing.get_origin(field_type)
+    if origin is typing.Union or origin is types.UnionType:
+        args = typing.get_args(field_type)
+        # Recursively get the base type of the first non-None argument
+        for arg in args:
+            if arg is not type(None):
+                return _get_base_type(arg)
+        return str  # All arguments were None, default to str
+
+    # If it's already a base type, return it directly
+    if field_type in (bool, int, float, str):
+        return field_type
+
+    try:
+        # Check in order: bool, int, float, str (bool is subclass of int)
+        if issubclass(field_type, bool):
+            return bool
+        if issubclass(field_type, int):
+            return int
+        if issubclass(field_type, float):
+            return float
+        if issubclass(field_type, str):
+            return str
+    except TypeError:
+        # issubclass() raises TypeError if field_type is not a class
+        pass
+    return str  # Default to str if not recognized
+
+
 def _field_to_sql_schema(field: dataclasses.Field) -> str:
     """Convert a dataclass field to a SQL column definition."""
     _validate_field_metadata(field)
     field_name = field.name
     field_type = field.type
-    sql_type = _TYPEMAP.get(field_type, "TEXT")
+    base_type = _get_base_type(field_type)
+    sql_type = _TYPEMAP.get(base_type, "TEXT")
     sql_field_constraints = []
 
     if field_name == "__constraints__":

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -91,8 +91,23 @@ def _get_base_type(field_type):
     """Get the base Python type for a field type.
 
     Returns one of: bool, int, float, str (or None if not a recognized type).
-    Handles both built-in types and schema types (which are subclasses).
+    Handles both built-in types, schema types (which are subclasses),
+    and Union/Optional types (e.g., int | None, Optional[int]).
     """
+    import types
+    import typing
+
+    # Handle Union/Optional types (e.g., int | None, Optional[int])
+    # Check for both typing.Union (old syntax) and types.UnionType (Python 3.10+ syntax)
+    origin = typing.get_origin(field_type)
+    if origin is typing.Union or origin is types.UnionType:
+        args = typing.get_args(field_type)
+        # Recursively get the base type of the first non-None argument
+        for arg in args:
+            if arg is not type(None):
+                return _get_base_type(arg)
+        return None  # All arguments were None
+
     # If it's already a base type, return it directly
     if field_type in (bool, int, float, str):
         return field_type


### PR DESCRIPTION
## Summary
Fixes #551 - SQLite backend was returning integers as strings due to Union type handling bug in `_get_base_type()`.

The function only checked for `typing.Union` (old `Optional[int]` syntax) but not `types.UnionType` (Python 3.10+ `int | None` syntax), causing columns with Union types to be declared as TEXT instead of INTEGER.

## Changes
- Add support for `types.UnionType` in `_get_base_type()`
- Apply fix to both `sqlite.py` and `postgres.py` backends
- Recursively extract base type from Union/Optional types

This ensures that `schema.Integer | None` fields are correctly typed as INTEGER columns, allowing SQLite to return proper int values instead of strings.

## Test plan
- [x] Verify schema.Integer | None fields are typed as INTEGER columns
- [x] Check that SQLite returns proper int values instead of strings
- [x] Test both sqlite.py and postgres.py backends
- [x] Sanity checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)