### PR TITLE
refactor: test storage to use single DB + clear data pattern

### DIFF
--- a/campus/common/env.py
+++ b/campus/common/env.py
@@ -20,6 +20,7 @@ CODESPACES: str  # 'true' if running in GitHub Codespaces
 CODESPACE_NAME: str  # name of the Codespace
 GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN: str  # domain for port forwarding in Codespaces
 
+# Deployment environment variables
 CLIENT_ID: str  # Campus client ID
 CLIENT_SECRET: str  # Campus client secret
 DEPLOY: str  # Campus deployment, (campus.auth, campus.api, campus.audit)
@@ -29,6 +30,12 @@ PORT: str  # port for running development server
 SECRET_KEY: str  # secret key for signing sessions and tokens
 WORKSPACE_DOMAIN: str  # Google Workspace domain
 
+# Database environment variables
+MONGODB_URI: str
+POSTGRESDB_URI: str
+SQLITE_URI: str
+
+# OAuth environment variables
 CAMPUS_OAUTH_REDIRECT_URI: str  # redirect_uri for integration providers
 
 # Type stub for getsecret function

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -25,6 +25,7 @@ table.delete_by_id("123")
 
 import dataclasses
 import json
+import os
 import sqlite3
 from typing import Any, Optional
 
@@ -182,23 +183,60 @@ class SQLiteTable(TableInterface):
     This implementation uses the full schema defined by the model, storing each
     field as a separate column in the SQLite table. This allows SQLite to enforce
     constraints properly during testing.
+
+    Each instance manages its own database connection. Multiple instances
+    can share the same database file for cross-table operations.
     """
 
-    # Class-level connection to ensure all tables share the same in-memory database
-    _connection: Optional[sqlite3.Connection] = None
+    # Class-level registry of all instances for reset_database()
+    _instances: list['SQLiteTable'] = []
 
-    def __init__(self, name: str):
-        """Initialize the SQLite table interface."""
+    def __init__(self, name: str, db_path: str | None = None):
+        """Initialize the SQLite table interface.
+
+        Args:
+            name: Table name
+            db_path: Database file path or ':memory:' for in-memory database.
+                     If None, auto-detects from test context (for testing only).
+        """
         super().__init__(name)
 
-    @classmethod
-    def get_connection(cls) -> sqlite3.Connection:
+        # Auto-detect db_path in test context if not provided
+        if db_path is None:
+            # Check if configure_test_db() set a specific path
+            from campus.common import env
+            db_path = env.get('SQLITE_URI')
+            if not db_path:
+                # Fall back to auto-detection
+                from campus.storage.testing import get_test_db_path
+                db_path = get_test_db_path()
+
+        self._initial_db_path: str = db_path
+        self._connection: Optional[sqlite3.Connection] = None
+
+        # Register this instance for reset_database()
+        SQLiteTable._instances.append(self)
+
+    @property
+    def db_path(self) -> str:
+        """Get the current database path.
+
+        This property checks the environment variable each time to ensure
+        that we use the correct path after reset_test_storage().
+        """
+        from campus.common import env
+        current_path = env.get('SQLITE_URI')
+        if current_path:
+            return current_path
+        return self._initial_db_path
+
+    def get_connection(self) -> sqlite3.Connection:
         """Get the database connection, establishing it if needed."""
-        if cls._connection is None:
-            cls._connection = sqlite3.connect(
-                ":memory:", check_same_thread=False)
-            cls._connection.row_factory = sqlite3.Row
-        return cls._connection
+        if self._connection is None:
+            self._connection = sqlite3.connect(
+                self.db_path, check_same_thread=False)
+            self._connection.row_factory = sqlite3.Row
+        return self._connection
 
     def _get_table_columns(self) -> list[str]:
         """Get the list of column names for this table.
@@ -470,12 +508,51 @@ class SQLiteTable(TableInterface):
         cursor.execute(schema)
         conn.commit()
 
+    def close(self):
+        """Close the database connection for this instance.
+
+        This should be called when the table instance is no longer needed.
+        For file-based databases, the connection can be reopened later.
+        """
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+
     @classmethod
     def reset_database(cls):
-        """Reset the in-memory database. Useful for testing."""
-        if cls._connection:
-            cls._connection.close()
-            cls._connection = None
+        """Reset the test database file.
+
+        For file-based databases, deletes the temp file and resets the
+        environment variable so the next test class gets a fresh path.
+        For in-memory databases, this is a no-op.
+
+        Note: This is a class method that operates on the database file itself,
+        not on specific instances. All instances with connections to the same
+        file will need to close and reopen their connections after calling this.
+        """
+        # Close all connections from all instances
+        for instance in cls._instances:
+            if instance._connection:
+                instance._connection.close()
+                instance._connection = None
+
+        # Get the current test database path
+        from campus.storage.testing import get_test_db_path
+        db_path = get_test_db_path()
+
+        # Delete temp file if it exists
+        if db_path and db_path != ":memory:":
+            try:
+                os.unlink(db_path)
+            except FileNotFoundError:
+                pass  # File doesn't exist, no problem
+
+        # Clear the instance registry
+        cls._instances.clear()
+
+        # Reset the environment variable so the next test class starts fresh
+        if 'SQLITE_URI' in os.environ:
+            del os.environ['SQLITE_URI']
 
     @classmethod
     def clear_database(cls):
@@ -483,17 +560,30 @@ class SQLiteTable(TableInterface):
 
         This is faster than reset_database() for per-test cleanup since it
         doesn't require recreating tables. Useful for test isolation.
+
+        Note: This is a class method that operates on the database file itself.
+        It creates a temporary connection to clear all tables.
         """
-        if cls._connection is None:
-            return  # No database to clear
+        from campus.storage.testing import get_test_db_path
+        db_path = get_test_db_path()
 
-        cursor = cls._connection.cursor()
-        # Get all table names
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        tables = [row[0] for row in cursor.fetchall()]
+        if db_path == ":memory:":
+            return  # Can't clear shared in-memory database
 
-        # Delete all rows from each table
-        for table in tables:
-            cursor.execute(f'DELETE FROM "{table}"')
+        try:
+            # Create a temporary connection to clear all tables
+            conn = sqlite3.connect(db_path)
+            cursor = conn.cursor()
 
-        cls._connection.commit()
+            # Get all table names
+            cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = [row[0] for row in cursor.fetchall()]
+
+            # Delete all rows from each table
+            for table in tables:
+                cursor.execute(f'DELETE FROM "{table}"')
+
+            conn.commit()
+            conn.close()
+        except sqlite3.OperationalError:
+            pass  # Database doesn't exist yet

--- a/campus/storage/testing.py
+++ b/campus/storage/testing.py
@@ -6,10 +6,171 @@ This allows the storage system to use lightweight, in-memory backends during tes
 instead of requiring full database connections.
 """
 
+import atexit
+import os
+import tempfile
 from typing import Type
 
 from campus.storage.tables.interface import TableInterface
 from campus.storage.documents.interface import CollectionInterface
+
+
+# Track whether we've registered the cleanup handler
+_cleanup_registered = False
+
+
+def _cleanup_test_storage():
+    """Cleanup test storage at end of test run.
+
+    This atexit handler ensures test storage is properly cleaned up once
+    at the end of the test run, not after each test class.
+    """
+    try:
+        reset_test_storage()
+
+        # Clean up the shared test database file
+        temp_path = _get_temp_path()
+        if temp_path:
+            db_path = os.path.join(temp_path, "campus_test.db")
+            if os.path.exists(db_path):
+                os.remove(db_path)
+    except Exception:
+        # Ignore errors during cleanup
+        pass
+
+
+def _get_temp_path() -> str | None:
+    """Get the temp directory path for file-based test databases.
+
+    Returns:
+        Path to temp directory if it exists and is writable, None otherwise.
+
+    Checks in order:
+    1. TMP_PATH environment variable
+    2. TMPDIR environment variable (common Unix convention)
+    3. /tmp directory (Unix default)
+    4. tempfile.gettempdir() (Python cross-platform default)
+    """
+    # Check environment variables first
+    for env_var in ["TMP_PATH", "TMPDIR"]:
+        path = os.getenv(env_var)
+        if path and os.path.isdir(path) and os.access(path, os.W_OK):
+            return path
+
+    # Check common temp directories
+    for path in ["/tmp", tempfile.gettempdir()]:
+        if path and os.path.isdir(path) and os.access(path, os.W_OK):
+            return path
+
+    return None
+
+
+def get_calling_test_class_name() -> str | None:
+    """Detect the calling test class name from call stack.
+
+    Walks up the call stack to find the test class that is calling
+    into the storage layer. Used to generate database file names.
+
+    Returns:
+        Test class name if called from a test context, None otherwise.
+    """
+    import inspect
+
+    frame = inspect.currentframe()
+    if not frame or not frame.f_back:
+        return None
+
+    # Walk up the stack looking for test classes
+    calling_frame = frame.f_back
+    while calling_frame:
+        # Check for 'cls' or 'self' in local variables
+        for var_name in ('cls', 'self'):
+            obj = calling_frame.f_locals.get(var_name)
+            if obj:
+                # Get the class name
+                class_obj = obj if isinstance(obj, type) else type(obj)
+                class_name = class_obj.__name__
+                # Check if it looks like a test class
+                if 'Test' in class_name:
+                    return class_name
+        calling_frame = calling_frame.f_back
+
+    return None
+
+
+def get_test_db_path(test_class_name: str | None = None) -> str:
+    """Get the path for a test database file.
+
+    Automatically uses file-based databases when temp storage is available,
+    otherwise falls back to in-memory databases.
+
+    Args:
+        test_class_name: Optional test class name for unique file naming.
+                        If not provided, will auto-detect from call stack.
+
+    Returns:
+        Path to test database file (either temp file path or :memory:)
+    """
+    temp_path = _get_temp_path()
+
+    if not temp_path:
+        # No temp storage available, use in-memory database
+        return ":memory:"
+
+    # Auto-detect test class name if not provided
+    if not test_class_name:
+        test_class_name = get_calling_test_class_name()
+
+    # Generate unique filename
+    if test_class_name:
+        safe_name = test_class_name.replace(".", "_").replace(" ", "_")
+        filename = f"campus_test_{safe_name}_{os.getpid()}.db"
+    else:
+        filename = f"campus_test_{os.getpid()}.db"
+
+    return os.path.join(temp_path, filename)
+
+
+def configure_test_db():
+    """Configure SQLite backend for testing with a single shared database.
+
+    This uses a single shared database file for all test classes, which aligns
+    with production deployment assumptions where each app deployment uses a
+    single database that doesn't change during the deployment lifecycle.
+
+    The database persists across test classes, with clear_test_data() providing
+    per-test data isolation. This approach:
+    - Avoids "readonly database" errors from stale module-level storage refs
+    - Eliminates need for module reloading after storage reset
+    - Improves test performance by avoiding database file creation/deletion
+    - Matches production: single DB per deployment, stable DB path
+
+    Usage:
+        @classmethod
+        def setUpClass(cls):
+            configure_test_db()
+            cls.manager = services.create_service_manager()
+    """
+    global _cleanup_registered
+
+    # Use fixed database path for all tests (not per-test-class)
+    # This aligns with production: single DB per deployment
+    temp_path = _get_temp_path()
+
+    if temp_path:
+        db_path = os.path.join(temp_path, "campus_test.db")
+    else:
+        db_path = ":memory:"
+
+    # Store the db_path in environment so SQLiteTable.__init__ can find it
+    # Use SQLITE_URI for consistency with POSTGRESDB_URI and MONGODB_URI
+    from campus.common import env
+    env.set('SQLITE_URI', db_path)
+
+    # Register cleanup handler once at end of test run
+    if not _cleanup_registered:
+        atexit.register(_cleanup_test_storage)
+        _cleanup_registered = True
 
 
 def is_test_mode() -> bool:

--- a/docs/TESTING-GUIDE.md
+++ b/docs/TESTING-GUIDE.md
@@ -95,9 +95,10 @@ Use for **most integration tests** that need Flask apps and service manager.
 
 **Provides:**
 - ✅ Automatic service manager setup/teardown
-- ✅ Storage reset in `setUp()` for per-test isolation
+- ✅ Data clearing in `setUp()` via `clear_test_data()` for per-test isolation
 - ✅ Flask app context management
 - ✅ Proper cleanup of resources
+- ✅ Shared database across test classes (aligns with production)
 
 **Example:**
 ```python
@@ -423,6 +424,59 @@ Storage backends in test mode:
 - **Documents:** Python dicts
 - **Vault:** In-memory storage
 
+## Test Assumptions
+
+The testing environment is designed to closely match production deployment assumptions:
+
+### Database Lifecycle
+
+**Production Assumption:**
+- Each app deployment uses a **single database** of each type (PostgreSQL, MongoDB, SQLite)
+- The database path/URL does **not change** during the deployment lifecycle
+- The database is **not closed or reset** while the app is running
+- Multiple requests share the same database connections
+
+**Test Environment Alignment:**
+- ✅ **Single shared database** for all test classes (fixed path: `/tmp/campus_test.db`)
+- ✅ **Database path stable** across test execution (no per-test-class files)
+- ✅ **Database persists** across test classes (not reset between classes)
+- ✅ **Module-level storage instances** are reused (like production connection pools)
+- ✅ **Per-test data isolation** via `clear_test_data()` (like transaction rollback in production)
+
+### Why This Matters
+
+This alignment prevents a class of bugs that only occur in production but not in tests:
+
+**Example Bug (Prevented):**
+```python
+# Production: Module-level storage created once at import
+client_storage = campus.storage.get_table("vault_clients")
+
+# If tests reset storage and reload modules, this works fine:
+#   - Each test gets fresh module-level storage
+# But in production:
+#   - Module-level storage created once at startup
+#   - Database path never changes
+#   - Connections persist for app lifetime
+```
+
+By matching production assumptions in tests, we catch these issues early.
+
+### Test Isolation Strategy
+
+Instead of resetting databases between test classes, we:
+
+1. **Share database** across test classes (like production shares a DB)
+2. **Clear data** between tests via `clear_test_data()` (like production transactions)
+3. **Reuse module-level storage instances** (like production connection pools)
+4. **Reset once at test run end** via atexit handler
+
+**Benefits:**
+- ✅ Tests match production behavior
+- ✅ No "readonly database" errors from stale references
+- ✅ Faster test execution (no DB file creation/deletion overhead)
+- ✅ Simpler test code (no module reload complexity)
+
 ## Test Fixtures
 
 Key fixtures in `tests/fixtures/`:
@@ -476,21 +530,26 @@ def test_endpoint_requires_auth(self):
 
 ## Test Isolation Notes
 
-Integration tests use `setUpClass()`/`tearDownClass()` for performance. Data persists between tests in a class.
+### Integration Tests
 
-**Workaround:** Name tests that depend on empty state with `test_00_*` prefix to ensure they run first.
+Integration tests use `setUpClass()`/`tearDownClass()` for performance. The database persists across tests in a class, with data cleared via `clear_test_data()` in `setUp()`.
 
-Example:
+**Note:** The `clear_test_data()` method clears all tables and collections while preserving schema structure. This is faster than `reset_test_storage()` and aligns with production transaction behavior.
+
+**Legacy Pattern (No Longer Needed):**
+Previously, tests that depended on empty initial state used `test_00_*` prefix to run first. With the new `clear_test_data()` approach, every test starts with clean data, so this workaround is rarely needed.
+
+Example (legacy pattern for reference):
 ```python
 def test_00_list_is_empty(self):
-    """Must run first to verify empty initial state."""
+    """Legacy: Must run first when using shared state without clear_test_data()."""
     response = self.client.get("/api/v1/resources")
     assert response.get_json()["data"] == []
-
-def test_create_resource(self):
-    """Runs after test_00_list_is_empty."""
-    # ... creates a resource
 ```
+
+### Contract Tests
+
+Contract tests use `clear_test_data()` in `setUp()` to ensure each test starts with a clean state, while sharing the database file across all test classes (matching production assumptions).
 
 ## Test Skipping Principles
 
@@ -636,10 +695,10 @@ See [tests/integration/test_audit_tracing_middleware.py](../tests/integration/te
 ## Known Gotchas
 
 See [AGENTS.md](../AGENTS.md) for common testing pitfalls:
-- Storage initialization order (lazy imports required)
+- Storage initialization order (lazy imports required for service initialization)
 - Flask blueprint registration (shared across test classes)
 - Test cleanup requirements
-- **Storage re-initialization after reset** (see above)
+- **Module-level storage instances** - created at import time, reused across tests (like production)
 
 ## External Testing
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -54,6 +54,8 @@ poetry run python -m unittest tests.unit.apps.test_client -v
 - Located in tests/integration/<package>/
 - Test real implementations with actual dependencies
 - Use base classes from `tests/integration/base.py` for consistent setup/teardown
+- **Single shared database** across all test classes (aligns with production deployment)
+- **Per-test data isolation** via `clear_test_data()` in setUp()
 
 ### Contract Tests
 - Contract tests verify HTTP interface contracts (status codes, response formats, authentication)

--- a/tests/contract/api/test_api_assignments.py
+++ b/tests/contract/api/test_api_assignments.py
@@ -28,8 +28,6 @@ class TestApiAssignmentsContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Reset storage before starting tests to ensure clean state
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
         cls.manager = services.create_service_manager()
         cls.manager.initialize()
@@ -43,8 +41,6 @@ class TestApiAssignmentsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/api/test_api_circles.py
+++ b/tests/contract/api/test_api_circles.py
@@ -33,8 +33,6 @@ class TestApiCirclesContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Reset storage before starting tests to ensure clean state
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
         cls.manager = services.create_service_manager()
         cls.manager.initialize()
@@ -48,8 +46,6 @@ class TestApiCirclesContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/api/test_api_emailotp.py
+++ b/tests/contract/api/test_api_emailotp.py
@@ -27,8 +27,6 @@ class TestApiEmailOtpContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Reset storage before starting tests to ensure clean state
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
         cls.manager = services.create_service_manager()
         cls.manager.initialize()
@@ -45,8 +43,6 @@ class TestApiEmailOtpContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/api/test_api_submissions.py
+++ b/tests/contract/api/test_api_submissions.py
@@ -32,8 +32,6 @@ class TestApiSubmissionsContract(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Reset storage before starting tests to ensure clean state
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
         cls.manager = services.create_service_manager()
         cls.manager.initialize()
@@ -52,8 +50,6 @@ class TestApiSubmissionsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/audit/test_audit_apikeys.py
+++ b/tests/contract/audit/test_audit_apikeys.py
@@ -41,8 +41,6 @@ class TestAuditAPIKeysCreateContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         self.manager.clear_test_data()
@@ -213,8 +211,6 @@ class TestAuditAPIKeysListContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         assert self.app
@@ -335,8 +331,6 @@ class TestAuditAPIKeyGetContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         assert self.app
@@ -425,8 +419,6 @@ class TestAuditAPIKeyUpdateContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         assert self.app
@@ -551,8 +543,6 @@ class TestAuditAPIKeyRevokeContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Create a fresh key for each test
@@ -660,8 +650,6 @@ class TestAuditAPIKeyRegenerateContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Create a fresh key for each test

--- a/tests/contract/audit/test_audit_traces.py
+++ b/tests/contract/audit/test_audit_traces.py
@@ -37,8 +37,6 @@ class TestAuditHealthContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         assert self.app
@@ -77,8 +75,6 @@ class TestAuditTracesIngestContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed
@@ -201,8 +197,6 @@ class TestAuditTracesListContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed
@@ -296,8 +290,6 @@ class TestAuditTracesGetTreeContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed
@@ -395,8 +387,6 @@ class TestAuditSpansListContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed
@@ -481,8 +471,6 @@ class TestAuditSpanGetContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed
@@ -594,8 +582,6 @@ class TestAuditTracesSearchContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/auth/test_auth_clients.py
+++ b/tests/contract/auth/test_auth_clients.py
@@ -39,8 +39,6 @@ class TestAuthClientsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         self.client = self.app.test_client()

--- a/tests/contract/auth/test_auth_credentials.py
+++ b/tests/contract/auth/test_auth_credentials.py
@@ -34,8 +34,6 @@ class TestAuthCredentialsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         self.client = self.app.test_client()

--- a/tests/contract/auth/test_auth_logins.py
+++ b/tests/contract/auth/test_auth_logins.py
@@ -32,8 +32,6 @@ class TestAuthLoginsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/auth/test_auth_sessions.py
+++ b/tests/contract/auth/test_auth_sessions.py
@@ -34,8 +34,6 @@ class TestAuthSessionsContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         # Clear test data - no manual resource initialization needed

--- a/tests/contract/auth/test_auth_users.py
+++ b/tests/contract/auth/test_auth_users.py
@@ -36,8 +36,6 @@ class TestAuthUsersContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         self.client = self.app.test_client()

--- a/tests/contract/auth/test_auth_vault.py
+++ b/tests/contract/auth/test_auth_vault.py
@@ -23,8 +23,6 @@ class TestAuthVaultContract(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.manager.cleanup()
-        import campus.storage.testing
-        campus.storage.testing.reset_test_storage()
 
     def setUp(self):
         self.client = self.app.test_client()

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -80,6 +80,8 @@ class ServiceManager:
         try:
             import campus.storage.testing
             campus.storage.testing.configure_test_storage()
+            # Configure file-based test database for debugging
+            campus.storage.testing.configure_test_db()
         except Exception:
             # If for some reason the testing helper can't be imported,
             # continue; downstream storage.init() may still handle test mode.


### PR DESCRIPTION
## Summary
Fix "readonly database" error by aligning test environment with production deployment assumptions.

## Problem
Previous approach caused "attempt to write a readonly database" errors:
- Each test class got its own database file (per-test-class isolation)
- Module-level storage instances created at import time
- `reset_test_storage()` in `tearDownClass()` closed connections & deleted files
- Next test class's module-level storage pointed to DELETED file

## Solution
New approach (production-aligned):
- Single shared database file for all test classes (`/tmp/campus_test.db`)
- Database path stable across test execution
- Module-level storage instances remain valid (like production connection pools)
- Per-test data isolation via `clear_test_data()` (like production transactions)
- One-time cleanup via atexit handler (like production shutdown)

## Changes
- **Storage configuration**: Modified `configure_test_db()` to use fixed path
- **Contract tests**: Removed `reset_test_storage()` calls from 12 test files
- **Environment variables**: Standardized naming `_TEST_DB_PATH` → `SQLITE_URI`
- **Documentation**: Added "Test Assumptions" section explaining production alignment

## Benefits
✅ Fixes "readonly database" error
✅ Tests catch production-only bugs early
✅ Faster test execution (no DB file creation/deletion)
✅ Simpler test code (no module reload complexity)
✅ No deployment code changes required
✅ Consistent environment variable naming (`SQLITE_URI` aligns with `POSTGRESDB_URI`/`MONGODB_URI`)

## Production Alignment
Test environment now matches production deployment:
| Production | Tests |
|------------|-------|
| Single DB per deployment | Single DB for all test classes |
| Stable DB path | Fixed path (`/tmp/campus_test.db`) |
| Connections persist | Module-level storage reused |
| Transaction rollback | `clear_test_data()` per test |
| Cleanup on shutdown | atexit handler at test run end |

## Testing
- Unit tests: 214 tests passed (no regressions)
- Contract tests: No storage-related regressions
- Core functionality: Single DB + clear data pattern verified