### PR TITLE
Fix test isolation bug in SQLiteTable.clear_database()

### DIFF
--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -624,8 +624,14 @@ class SQLiteTable(TableInterface):
         Note: This is a class method that operates on the database file itself.
         It uses the shared connection with proper locking to clear all tables.
         """
-        from campus.storage.testing import get_test_db_path
-        db_path = get_test_db_path()
+        # Use the same path resolution as the db_path property
+        # to ensure we clear the correct database file
+        from campus.common import env
+        db_path = env.get('SQLITE_URI')
+        if not db_path:
+            # Fall back to auto-detection if SQLITE_URI not set
+            from campus.storage.testing import get_test_db_path
+            db_path = get_test_db_path()
 
         if db_path == ":memory:":
             return  # Can't clear shared in-memory database


### PR DESCRIPTION
## Summary
Fixes test isolation failure where `SQLiteTable.clear_database()` was using a different database path resolution strategy than the rest of the test infrastructure, causing test data to not be cleared between tests.

## Problem
The `test_list_returns_all_users` test was failing with `AssertionError: 5 != 3` - it was returning 5 users instead of the expected 3. This was caused by data leakage from previous tests.

### Root Cause
- **Test setup** (`configure_test_db()`): Set `SQLITE_URI` to `/tmp/campus_test.db` (fixed path)
- **Test operations** (`db_path` property): Read from `SQLITE_URI` env var → `/tmp/campus_test.db`
- **Data clearing** (`clear_database()`): Called `get_test_db_path()` which auto-detected from call stack → `/tmp/campus_test_TestUsersResourceGetOrCreate_<pid>.db`

This path mismatch meant `clear_database()` was attempting to clear the wrong file, leaving the actual test database intact between tests.

## Solution
Modified `SQLiteTable.clear_database()` to use the same path resolution logic as the `db_path` property:
1. Check `SQLITE_URI` environment variable first
2. Fall back to auto-detection only if `SQLITE_URI` is not set

This ensures the method clears the correct database file that was configured during test setup.

## Changes
- Modified `campus/storage/tables/backend/sqlite.py::SQLiteTable.clear_database()`
- Added check for `SQLITE_URI` before falling back to `get_test_db_path()`
- Added comments explaining the path resolution strategy

## Test Results
- ✅ `test_list_returns_all_users` now passes (was failing)
- ✅ All 6 tests in `TestUsersResourceGetOrCreate` pass
- ✅ Test isolation is restored - data is properly cleared between tests
- ✅ Sanity checks passed

## Impact
This fix restores proper test isolation for all integration tests using `clear_all_data()` for per-test cleanup. Previously, tests could leak data to subsequent tests, causing false positives and hard-to-debug failures.