### PR TITLE
fix(oauth): set session user_id after Google callback for device flow

### DIFF
--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -356,19 +356,27 @@ def device_verification(user_code: str | None = None):
     import html
 
     # Check if user is authenticated (for both GET and POST)
+    # First check Flask session, then check query param (from Google OAuth callback)
     user_id = session.get('user_id')
     if not user_id:
-        # User not logged in - redirect to Google OAuth login
-        # After login, they'll return to this page to authorize the device
-        login_callback = url_for('auth.oauth.device_verification', _external=True)
-        if user_code:
-            login_callback += f"/{user_code}"
-        oauth_authorize_url = url_for(
-            'auth.google.authorize',
-            _external=True,
-            target=login_callback
-        )
-        return redirect(oauth_authorize_url)
+        # Check if user_id is in query params (from Google OAuth callback)
+        user_param = request.args.get('user')
+        if user_param:
+            # Set the session for subsequent requests
+            session['user_id'] = user_param
+            user_id = user_param
+        else:
+            # User not logged in - redirect to Google OAuth login
+            # After login, they'll return to this page to authorize the device
+            login_callback = url_for('auth.oauth.device_verification', _external=True)
+            if user_code:
+                login_callback += f"/{user_code}"
+            oauth_authorize_url = url_for(
+                'auth.google.authorize',
+                _external=True,
+                target=login_callback
+            )
+            return redirect(oauth_authorize_url)
 
     # Handle POST for non-JS fallback
     if request.method == "POST":


### PR DESCRIPTION
## Summary
- Fix device authorization OAuth flow getting stuck in redirect loop
- Device verification page now checks for `user` query param from Google OAuth callback
- Sets `session['user_id']` when user returns from Google authentication

## Test plan
- [ ] Run `poetry run campus auth login` in campus-cli
- [ ] Verify Google account selection completes authorization
- [ ] Verify CLI receives access token after authorization

## Root cause
The `device_verification` endpoint only checked `session.get('user_id')`, but the Google OAuth callback redirects with `?user=<user_id>` query parameter instead of setting the session. This caused users to be stuck in a redirect loop when selecting their Google account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)