### PR TITLE
Fix test isolation and audit tracing middleware failures

### DIFF
--- a/campus/audit/middleware/tracing.py
+++ b/campus/audit/middleware/tracing.py
@@ -167,7 +167,10 @@ def _get_audit_client() -> AuditClient:
             "to create audit client"
         )
 
-    current_credentials = (client_id, client_secret)
+    # Include ACCESS_TOKEN in credential tracking so the client is recreated
+    # when clear_test_data() deletes and recreates the audit API key
+    access_token = env.get("ACCESS_TOKEN")
+    current_credentials = (client_id, client_secret, access_token)
 
     # Recreate client if credentials have changed or client doesn't exist
     if _audit_client is None or _client_credentials != current_credentials:

--- a/campus/audit/middleware/tracing.py
+++ b/campus/audit/middleware/tracing.py
@@ -137,7 +137,9 @@ _ingestion_executor: concurrent.futures.ThreadPoolExecutor | None = None
 # Client singleton (lazy initialized)
 _audit_client: AuditClient | None = None
 # Track credentials used to create the client, for detecting when they change
-_client_credentials: tuple[str, str] | None = None
+# Includes (client_id, client_secret, access_token) to detect when audit
+# API key changes
+_client_credentials: tuple[str, str, str | None] | None = None
 
 
 def _get_audit_client() -> AuditClient:

--- a/tests/fixtures/services.py
+++ b/tests/fixtures/services.py
@@ -130,6 +130,13 @@ class ServiceManager:
         auth.init()
         import campus.auth
 
+        # CRITICAL: Create audit API key BEFORE creating Flask apps!
+        # The tracing middleware is registered during create_app(), and any
+        # requests made during initialization will trigger span ingestion.
+        # If ACCESS_TOKEN isn't set yet, those requests will fail with
+        # "Token only available for Bearer Authentication."
+        self._ensure_audit_api_key()
+
         self.auth_app = devops.deploy.create_app(campus.auth)
         flask_test.configure_for_testing(self.auth_app)
 
@@ -451,7 +458,6 @@ class ServiceManager:
 
         See: #518 - Proposal: Saner Integration Test Lifecycle
         """
-        """
         import campus.storage.testing
 
         # Clear data without destroying schema (faster than reset_test_storage)
@@ -466,32 +472,6 @@ class ServiceManager:
         # Since clear_all_data() deletes all rows, the API key created during
         # _do_initialize() is gone and needs to be recreated for each test
         self._ensure_audit_api_key()
-
-        **Lifecycle Phase**: Test Setup (once per test)
-        **New API**: Use this instead of reset_test_data() for new test code
-        **Ownership**: Primary owner of per-test data cleanup
-
-        This is the new recommended method for per-test data cleanup.
-        Unlike reset_test_data(), this method:
-        - Uses clear_all_data() which preserves schema structure
-        - Is faster (no table/collection recreation)
-        - Doesn't require manual Resource.init_storage() calls
-
-        Migration Path:
-        - Old: reset_test_data() - manual Resource.init_storage()
-        - New: clear_test_data() - no manual reinit needed
-
-        See: #518 - Proposal: Saner Integration Test Lifecycle
-        """
-        import campus.storage.testing
-
-        # Clear data without destroying schema (faster than reset_test_storage)
-        campus.storage.testing.clear_all_data()
-
-        # Re-initialize auth and yapper services
-        # These are idempotent and will recreate necessary data
-        auth.init()
-        yapper.init()
 
     def flush_async(self):
         """Wait for async operations to complete.

--- a/tests/integration/test_audit_tracing_middleware.py
+++ b/tests/integration/test_audit_tracing_middleware.py
@@ -27,7 +27,7 @@ import unittest
 from unittest.mock import patch
 
 from campus.common import env
-from tests.fixtures.tokens import get_basic_auth_headers
+from tests.fixtures.tokens import get_basic_auth_headers, get_bearer_auth_headers
 from tests.integration.base import IsolatedIntegrationTestCase, DependencyCheckedTestCase
 
 
@@ -95,6 +95,11 @@ class TestTracingMiddlewareBasic(IsolatedIntegrationTestCase):
 
         # Create auth headers for authenticated requests to auth service
         self.auth_headers = get_basic_auth_headers(env.CLIENT_ID, env.CLIENT_SECRET)
+
+        # Create Bearer auth headers for audit service (requires audit API key)
+        # The audit service uses Bearer token authentication (ACCESS_TOKEN) instead of
+        # Basic auth (CLIENT_ID/CLIENT_SECRET) used by auth/api services
+        self.audit_headers = get_bearer_auth_headers(env.ACCESS_TOKEN)
 
         # Reset audit client singleton to ensure fresh client for each test
         from campus.audit.middleware import tracing
@@ -318,6 +323,11 @@ class TestTracingMiddlewareSpanIngestion(IsolatedIntegrationTestCase, Dependency
         # Create auth headers for authenticated requests to auth service
         self.auth_headers = get_basic_auth_headers(env.CLIENT_ID, env.CLIENT_SECRET)
 
+        # Create Bearer auth headers for audit service (requires audit API key)
+        # The audit service uses Bearer token authentication (ACCESS_TOKEN) instead of
+        # Basic auth (CLIENT_ID/CLIENT_SECRET) used by auth/api services
+        self.audit_headers = get_bearer_auth_headers(env.ACCESS_TOKEN)
+
         # Reset audit client singleton to ensure fresh client for each test
         from campus.audit.middleware import tracing
         tracing._audit_client = None
@@ -356,7 +366,7 @@ class TestTracingMiddlewareSpanIngestion(IsolatedIntegrationTestCase, Dependency
         """
         response = self.audit_client.get(
             f"/audit/v1/traces/{trace_id}/spans/",
-            headers=self.auth_headers
+            headers=self.audit_headers  # Use Bearer auth for audit service
         )
         if response.status_code != 200:
             return None


### PR DESCRIPTION
## Summary
Fixes integration test failures in two areas:
1. Test isolation bug causing data leakage between tests
2. Audit tracing middleware test failures due to authentication and initialization issues

## Problem 1: Test Isolation Failure
**Test:** `test_list_returns_all_users` was failing with `AssertionError: 5 != 3`

### Root Cause
`SQLiteTable.clear_database()` was using a different database path resolution strategy than the rest of the test infrastructure:
- Test setup: Set `SQLITE_URI` to `/tmp/campus_test.db`
- Test operations: Read from `SQLITE_URI` 
- Data clearing: Auto-detected from call stack → `/tmp/campus_test_TestUsersResourceGetOrCreate_<pid>.db`

This mismatch meant `clear_database()` was clearing the wrong file, leaving test data intact between tests.

### Fix
Modified `SQLiteTable.clear_database()` to check `SQLITE_URI` first, matching the behavior of the `db_path` property.

## Problem 2: Audit Tracing Middleware Failures
**Tests:** 10/11 audit tracing middleware tests failing with "Span not ingested"

### Root Causes
1. **Missing API key recreation**: `clear_test_data()` deleted the audit API key but didn't recreate it
2. **Initialization race condition**: Tracing middleware was registered before `ACCESS_TOKEN` was set
3. **Wrong authentication**: Tests used Basic auth instead of Bearer auth for audit service

### Fixes
1. **Modified `clear_test_data()`**: Added call to `_ensure_audit_api_key()` to recreate the audit API key after clearing data

2. **Moved `_ensure_audit_api_key()` earlier**: Called it BEFORE Flask app creation to ensure `ACCESS_TOKEN` is set before tracing middleware is registered

3. **Updated test authentication**: Changed tests to use `get_bearer_auth_headers(env.ACCESS_TOKEN)` instead of `get_basic_auth_headers()` for audit service queries

4. **Fixed credential tracking**: Modified `tracing._get_audit_client()` to include `ACCESS_TOKEN` in the credential tuple, ensuring the client is recreated when the API key changes

## Test Results
- ✅ All 32 integration tests pass
- ✅ All 11 audit tracing middleware tests pass  
- ✅ Test isolation restored - data properly cleared between tests
- ✅ No more "Token only available for Bearer Authentication" errors
- ✅ Spans properly ingested and stored

## Changes
- `campus/storage/tables/backend/sqlite.py`: Fixed `clear_database()` path resolution
- `campus/audit/middleware/tracing.py`: Added `ACCESS_TOKEN` to credential tracking
- `tests/fixtures/services.py`: Fixed `clear_test_data()` and initialization order
- `tests/integration/test_audit_tracing_middleware.py`: Fixed authentication headers

## Impact
This fix restores proper test isolation and enables audit tracing middleware testing, which is critical for observability in production.