### PR TITLE
Fix KeyError JSON serialization bug in timetable route

### DIFF
--- a/campus/api/routes/timetable.py
+++ b/campus/api/routes/timetable.py
@@ -136,14 +136,10 @@ def new(
             "'data' object requires 'lessongroups' property",
             **details
         )
-    try:
-        timetable = timetable_resource.new(
-            metadata=metadata,
-            lessongroups=data["lessongroups"]
-        )
-    except Exception as e:
-        return {'error': e}, 400
-
+    timetable = timetable_resource.new(
+        metadata=metadata,
+        lessongroups=data["lessongroups"]
+    )
     return {"data": timetable.to_resource()}, 200
 
 @bp.get('/<timetable_id>/')


### PR DESCRIPTION
## Summary

Fixes #564

Remove try-except block that was returning exception object directly in response dict, causing JSON serialization failures.

## The Bug

The POST /timetable/ route had a try-except block catching generic Exception:
```python
except Exception as e:
    return {'error': e}, 400  # BUG: 'e' is the exception object
```

When a `KeyError` was raised, the route returned `{'error': <KeyError object>}` which Flask's JSON serializer couldn't handle, resulting in:
```
TypeError: Object of type KeyError is not JSON serializable
```

## The Fix

Remove the try-except block entirely. Exceptions now propagate to the global error handler ([`campus/common/errors/handlers.py`](campus/common/errors/handlers.py)) which properly converts them to API errors with appropriate status codes and string messages.

## Changes

- [campus/api/routes/timetable.py:139-145](campus/api/routes/timetable.py#L139-L145) - Removed try-except block
- Now exceptions from `timetable_resource.new()` propagate to global error handler
- Consistent with error handling pattern used in other routes (e.g., [`auth/routes/oauth.py:279-280`](campus/auth/routes/oauth.py#L279-L280))

## Test Plan

- [x] Sanity checks pass
- [ ] Unit tests for timetable POST route
- [ ] Integration test with invalid data (should now return proper error response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)