### PR TITLE
Fix API URL trailing slash pattern compliance

### DIFF
--- a/campus/api/routes/assignments.py
+++ b/campus/api/routes/assignments.py
@@ -100,7 +100,7 @@ def create_assignment(
     return resource, 201
 
 
-@bp.get('/<string:assignment_id>')
+@bp.get('/<string:assignment_id>/')
 def get_assignment(assignment_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Get a single assignment by ID.
@@ -116,7 +116,7 @@ def get_assignment(assignment_id: str) -> flask_campus.JsonResponse:
     return assignment.to_resource(), 200
 
 
-@bp.patch('/<string:assignment_id>')
+@bp.patch('/<string:assignment_id>/')
 @flask_campus.unpack_request
 def update_assignment(
     *,
@@ -163,7 +163,7 @@ def update_assignment(
     return {}, 200
 
 
-@bp.delete('/<string:assignment_id>')
+@bp.delete('/<string:assignment_id>/')
 def delete_assignment(assignment_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Delete an assignment.

--- a/campus/api/routes/circles.py
+++ b/campus/api/routes/circles.py
@@ -106,7 +106,7 @@ def new_circle(
     return resource, 201
 
 
-@bp.delete('/<string:circle_id>')
+@bp.delete('/<string:circle_id>/')
 def delete_circle(circle_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Delete a circle by its unique ID.
@@ -146,7 +146,7 @@ def delete_circle(circle_id: str) -> flask_campus.JsonResponse:
     return {}, 200
 
 
-@bp.get('/<string:circle_id>')
+@bp.get('/<string:circle_id>/')
 def get_circle_details(circle_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Retrieve detailed information about a specific circle.
@@ -195,7 +195,7 @@ def get_circle_details(circle_id: str) -> flask_campus.JsonResponse:
     return resource, 200
 
 
-@bp.patch('/<string:circle_id>')
+@bp.patch('/<string:circle_id>/')
 @flask_campus.unpack_request
 def edit_circle(
         *,
@@ -257,7 +257,7 @@ def move_circle(circle_id: str) -> flask_campus.JsonResponse:
     return {"message": "Not implemented"}, 501
 
 
-@bp.get('/<string:circle_id>/members')
+@bp.get('/<string:circle_id>/members/')
 def get_circle_members(circle_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Retrieve the member IDs of a circle along with their access values.
@@ -405,7 +405,7 @@ def remove_circle_member(
 # TODO: Redesign for clearer access update: circles can have multiple parentage paths
 
 
-@bp.patch('/<string:circle_id>/members')
+@bp.patch('/<string:circle_id>/members/')
 @flask_campus.unpack_request
 def patch_circle_member(
         *,

--- a/campus/api/routes/submissions.py
+++ b/campus/api/routes/submissions.py
@@ -139,7 +139,7 @@ def list_submissions_by_student(
     return {"data": [submission.to_resource() for submission in result]}, 200
 
 
-@bp.get('/<string:submission_id>')
+@bp.get('/<string:submission_id>/')
 def get_submission(submission_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Get a single submission by ID.
@@ -155,7 +155,7 @@ def get_submission(submission_id: str) -> flask_campus.JsonResponse:
     return submission.to_resource(), 200
 
 
-@bp.patch('/<string:submission_id>')
+@bp.patch('/<string:submission_id>/')
 @flask_campus.unpack_request
 def update_submission(
     *,
@@ -199,7 +199,7 @@ def update_submission(
     return {}, 200
 
 
-@bp.delete('/<string:submission_id>')
+@bp.delete('/<string:submission_id>/')
 def delete_submission(submission_id: str) -> flask_campus.JsonResponse:
     """Summary:
         Delete a submission.

--- a/campus/auth/routes/users.py
+++ b/campus/auth/routes/users.py
@@ -66,7 +66,7 @@ def activate(user_id: schema.UserID) -> flask_campus.JsonResponse:
     return activated_user.to_resource(), 200
 
 
-@bp.delete("/<user_id>")
+@bp.delete("/<user_id>/")
 @flask_campus.unpack_request
 def delete_user(user_id: schema.UserID) -> flask_campus.JsonResponse:
     """Delete a user
@@ -79,7 +79,7 @@ def delete_user(user_id: schema.UserID) -> flask_campus.JsonResponse:
     return {}, 200
 
 
-@bp.get("/<user_id>")
+@bp.get("/<user_id>/")
 @flask_campus.unpack_request
 def get(user_id: schema.UserID) -> flask_campus.JsonResponse:
     """Get details of a specific user
@@ -95,7 +95,7 @@ def get(user_id: schema.UserID) -> flask_campus.JsonResponse:
     return user.to_resource(), 200
 
 
-@bp.patch("/<user_id>")
+@bp.patch("/<user_id>/")
 @flask_campus.unpack_request
 def update() -> flask_campus.JsonResponse:
     """Update a user
@@ -119,8 +119,8 @@ def create_blueprint() -> flask.Blueprint:
     new_bp.add_url_rule("/", "get_all", get_all, methods=["GET"])
     new_bp.add_url_rule("/", "new", new, methods=["POST"])
     new_bp.add_url_rule("/<user_id>/activate", "activate", activate, methods=["POST"])
-    new_bp.add_url_rule("/<user_id>", "delete_user", delete_user, methods=["DELETE"])
-    new_bp.add_url_rule("/<user_id>", "get", get, methods=["GET"])
-    new_bp.add_url_rule("/<user_id>", "update", update, methods=["PATCH"])
+    new_bp.add_url_rule("/<user_id>/", "delete_user", delete_user, methods=["DELETE"])
+    new_bp.add_url_rule("/<user_id>/", "get", get, methods=["GET"])
+    new_bp.add_url_rule("/<user_id>/", "update", update, methods=["PATCH"])
 
     return new_bp

--- a/tests/contract/api/test_api_assignments.py
+++ b/tests/contract/api/test_api_assignments.py
@@ -9,9 +9,9 @@ This is enforced via before_request hook in the API blueprint.
 Assignments Endpoints Reference:
 - GET    /assignments/                      - List all assignments with optional filters
 - POST   /assignments/                      - Create a new assignment
-- GET    /assignments/{assignment_id}       - Get a single assignment
-- PATCH  /assignments/{assignment_id}       - Update an assignment
-- DELETE /assignments/{assignment_id}       - Delete an assignment
+- GET    /assignments/{assignment_id}/      - Get a single assignment
+- PATCH  /assignments/{assignment_id}/      - Update an assignment
+- DELETE /assignments/{assignment_id}/      - Delete an assignment
 - POST   /assignments/{assignment_id}/links - Add a Classroom link
 """
 
@@ -191,7 +191,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.get(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
 
@@ -216,7 +216,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
     def test_get_missing_assignment_returns_error(self):
         """GET /assignments/{assignment_id} for non-existent assignment returns error."""
         response = self.client.get(
-            "/api/v1/assignments/nonexistent_id",
+            "/api/v1/assignments/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -227,7 +227,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={"title": "Updated Title"},
             headers=self.auth_headers
         )
@@ -238,7 +238,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
 
         # Verify the update
         get_response = self.client.get(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
         assignment_data = get_response.get_json()
@@ -249,7 +249,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={"description": "Updated description"},
             headers=self.auth_headers
         )
@@ -267,7 +267,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
             {"id": "q2", "prompt": "p2", "question": "New question 2"},
         ]
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={"questions": new_questions},
             headers=self.auth_headers
         )
@@ -279,7 +279,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={
                 "title": "New Title",
                 "description": "New Description",
@@ -291,7 +291,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
 
         # Verify both updates
         get_response = self.client.get(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
         assignment_data = get_response.get_json()
@@ -303,7 +303,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={},
             headers=self.auth_headers
         )
@@ -319,7 +319,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.patch(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             json={"title": "Updated Title"},
         )
 
@@ -337,7 +337,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         intentional (idempotent updates) or a bug.
         """
         response = self.client.patch(
-            "/api/v1/assignments/nonexistent_id",
+            "/api/v1/assignments/nonexistent_id/",
             json={"title": "Updated Title"},
             headers=self.auth_headers
         )
@@ -352,7 +352,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.delete(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
 
@@ -362,7 +362,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
 
         # Verify it's deleted
         get_response = self.client.get(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
         self.assertIn(get_response.status_code, (404, 409))
@@ -372,7 +372,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
         assignment_id = self._create_test_assignment()
 
         response = self.client.delete(
-            f"/api/v1/assignments/{assignment_id}"
+            f"/api/v1/assignments/{assignment_id}/"
         )
 
         self.assertEqual(response.status_code, 401)
@@ -384,7 +384,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
     def test_delete_missing_assignment_returns_error(self):
         """DELETE /assignments/{assignment_id} for non-existent assignment returns error."""
         response = self.client.delete(
-            "/api/v1/assignments/nonexistent_id",
+            "/api/v1/assignments/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -410,7 +410,7 @@ class TestApiAssignmentsContract(unittest.TestCase):
 
         # Verify the link was added
         get_response = self.client.get(
-            f"/api/v1/assignments/{assignment_id}",
+            f"/api/v1/assignments/{assignment_id}/",
             headers=self.auth_headers
         )
         assignment_data = get_response.get_json()

--- a/tests/contract/api/test_api_circles.py
+++ b/tests/contract/api/test_api_circles.py
@@ -9,14 +9,14 @@ This is enforced via before_request hook in the API blueprint.
 Circles Endpoints Reference:
 - GET    /circles/                              - List all circles with optional tag filter
 - POST   /circles/                              - Create a new circle
-- GET    /circles/{circle_id}                   - Get a single circle
-- PATCH  /circles/{circle_id}                   - Update a circle (name, description)
-- DELETE /circles/{circle_id}                   - Delete a circle
+- GET    /circles/{circle_id}/                  - Get a single circle
+- PATCH  /circles/{circle_id}/                  - Update a circle (name, description)
+- DELETE /circles/{circle_id}/                  - Delete a circle
 - POST   /circles/{circle_id}/move              - Move circle (not implemented - 501)
-- GET    /circles/{circle_id}/members           - Get circle members
+- GET    /circles/{circle_id}/members/          - Get circle members
 - POST   /circles/{circle_id}/members/add       - Add a member to a circle
 - DELETE /circles/{circle_id}/members/remove    - Remove a member from a circle
-- PATCH  /circles/{circle_id}/members           - Update member access level
+- PATCH  /circles/{circle_id}/members/          - Update member access level
 - GET    /circles/{circle_id}/users             - Get users in circle (not implemented - 501)
 """
 
@@ -221,11 +221,11 @@ class TestApiCirclesContract(unittest.TestCase):
     # Get Circle Tests
 
     def test_get_circle_by_id(self):
-        """GET /circles/{circle_id} returns the circle."""
+        """GET /circles/{circle_id}/ returns the circle."""
         circle_id = self._create_test_circle(name="Get Test Circle")
 
         response = self.client.get(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             headers=self.auth_headers
         )
 
@@ -239,8 +239,8 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertIn("sources", data)
 
     def test_get_circle_requires_auth(self):
-        """GET /circles/{circle_id} without auth returns 401."""
-        response = self.client.get("/api/v1/circles/some_id")
+        """GET /circles/{circle_id}/ without auth returns 401."""
+        response = self.client.get("/api/v1/circles/some_id/")
 
         self.assertEqual(response.status_code, 401)
         data = response.get_json()
@@ -249,9 +249,9 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertEqual(data["error"]["code"], "UNAUTHORIZED")
 
     def test_get_missing_circle_returns_error(self):
-        """GET /circles/{circle_id} for non-existent circle returns 409."""
+        """GET /circles/{circle_id}/ for non-existent circle returns 409."""
         response = self.client.get(
-            "/api/v1/circles/nonexistent_id",
+            "/api/v1/circles/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -263,13 +263,13 @@ class TestApiCirclesContract(unittest.TestCase):
 
     # Update Circle Tests
 
-    @unittest.skip("API BUG: PATCH /circles/{id} returns 500 for all update operations")
+    @unittest.skip("API BUG: PATCH /circles/{id}/ returns 500 for all update operations")
     def test_update_circle_name(self):
-        """PATCH /circles/{circle_id} updates name."""
+        """PATCH /circles/{circle_id}/ updates name."""
         circle_id = self._create_test_circle(name="Original Name")
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             json={"name": "Updated Name"},
             headers=self.auth_headers
         )
@@ -280,32 +280,32 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Verify the update
         get_response = self.client.get(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             headers=self.auth_headers
         )
         circle_data = get_response.get_json()
         self.assertEqual(circle_data["name"], "Updated Name")
 
-    @unittest.skip("API BUG: PATCH /circles/{id} returns 500 for all update operations")
+    @unittest.skip("API BUG: PATCH /circles/{id}/ returns 500 for all update operations")
     def test_update_circle_description(self):
-        """PATCH /circles/{circle_id} updates description."""
+        """PATCH /circles/{circle_id}/ updates description."""
         circle_id = self._create_test_circle(description="Original Description")
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             json={"description": "Updated Description"},
             headers=self.auth_headers
         )
 
         self.assertEqual(response.status_code, 200)
 
-    @unittest.skip("API BUG: PATCH /circles/{id} returns 500 for all update operations")
+    @unittest.skip("API BUG: PATCH /circles/{id}/ returns 500 for all update operations")
     def test_update_circle_both_fields(self):
-        """PATCH /circles/{circle_id} updates both name and description."""
+        """PATCH /circles/{circle_id}/ updates both name and description."""
         circle_id = self._create_test_circle()
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             json={
                 "name": "New Name",
                 "description": "New Description",
@@ -315,13 +315,13 @@ class TestApiCirclesContract(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
 
-    @unittest.skip("API BUG: PATCH /circles/{id} returns 500 for all update operations (including empty body)")
+    @unittest.skip("API BUG: PATCH /circles/{id}/ returns 500 for all update operations (including empty body)")
     def test_update_circle_empty_body_returns_error(self):
-        """PATCH /circles/{circle_id} without updates returns 400."""
+        """PATCH /circles/{circle_id}/ without updates returns 400."""
         circle_id = self._create_test_circle()
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             json={},
             headers=self.auth_headers
         )
@@ -333,21 +333,21 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertEqual(data["error"]["code"], "INVALID_REQUEST")
 
     def test_update_circle_requires_auth(self):
-        """PATCH /circles/{circle_id} without auth returns 401."""
+        """PATCH /circles/{circle_id}/ without auth returns 401."""
         circle_id = self._create_test_circle()
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             json={"name": "Updated Name"}
         )
 
         self.assertEqual(response.status_code, 401)
 
-    @unittest.skip("API BUG: PATCH /circles/{id} returns 500 for all update operations (including missing circle)")
+    @unittest.skip("API BUG: PATCH /circles/{id}/ returns 500 for all update operations (including missing circle)")
     def test_update_missing_circle_returns_error(self):
-        """PATCH /circles/{circle_id} for non-existent circle returns 409."""
+        """PATCH /circles/{circle_id}/ for non-existent circle returns 409."""
         response = self.client.patch(
-            "/api/v1/circles/nonexistent_id",
+            "/api/v1/circles/nonexistent_id/",
             json={"name": "Updated Name"},
             headers=self.auth_headers
         )
@@ -357,11 +357,11 @@ class TestApiCirclesContract(unittest.TestCase):
     # Delete Circle Tests
 
     def test_delete_circle(self):
-        """DELETE /circles/{circle_id} removes the circle."""
+        """DELETE /circles/{circle_id}/ removes the circle."""
         circle_id = self._create_test_circle(name="To Be Deleted")
 
         response = self.client.delete(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             headers=self.auth_headers
         )
 
@@ -371,26 +371,26 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Verify it's deleted
         get_response = self.client.get(
-            f"/api/v1/circles/{circle_id}",
+            f"/api/v1/circles/{circle_id}/",
             headers=self.auth_headers
         )
         self.assertEqual(get_response.status_code, 409)
 
     def test_delete_circle_requires_auth(self):
-        """DELETE /circles/{circle_id} without auth returns 401."""
+        """DELETE /circles/{circle_id}/ without auth returns 401."""
         circle_id = self._create_test_circle()
 
         response = self.client.delete(
-            f"/api/v1/circles/{circle_id}"
+            f"/api/v1/circles/{circle_id}/"
         )
 
         self.assertEqual(response.status_code, 401)
 
-    @unittest.skip("API BUG: DELETE /circles/{id} for non-existent circle returns 200 instead of 409")
+    @unittest.skip("API BUG: DELETE /circles/{id}/ for non-existent circle returns 200 instead of 409")
     def test_delete_missing_circle_returns_error(self):
-        """DELETE /circles/{circle_id} for non-existent circle returns 409."""
+        """DELETE /circles/{circle_id}/ for non-existent circle returns 409."""
         response = self.client.delete(
-            "/api/v1/circles/nonexistent_id",
+            "/api/v1/circles/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -415,11 +415,11 @@ class TestApiCirclesContract(unittest.TestCase):
     # Circle Members Tests
 
     def test_get_circle_members(self):
-        """GET /circles/{circle_id}/members returns members dict."""
+        """GET /circles/{circle_id}/members/ returns members dict."""
         circle_id = self._create_test_circle()
 
         response = self.client.get(
-            f"/api/v1/circles/{circle_id}/members",
+            f"/api/v1/circles/{circle_id}/members/",
             headers=self.auth_headers
         )
 
@@ -428,19 +428,19 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertIsInstance(data, dict)
 
     def test_get_circle_members_requires_auth(self):
-        """GET /circles/{circle_id}/members without auth returns 401."""
+        """GET /circles/{circle_id}/members/ without auth returns 401."""
         circle_id = self._create_test_circle()
 
         response = self.client.get(
-            f"/api/v1/circles/{circle_id}/members"
+            f"/api/v1/circles/{circle_id}/members/"
         )
 
         self.assertEqual(response.status_code, 401)
 
     def test_get_members_missing_circle_returns_error(self):
-        """GET /circles/{circle_id}/members for non-existent circle returns 409."""
+        """GET /circles/{circle_id}/members/ for non-existent circle returns 409."""
         response = self.client.get(
-            "/api/v1/circles/nonexistent_id/members",
+            "/api/v1/circles/nonexistent_id/members/",
             headers=self.auth_headers
         )
 
@@ -467,7 +467,7 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Verify member was added
         members_response = self.client.get(
-            f"/api/v1/circles/{parent_id}/members",
+            f"/api/v1/circles/{parent_id}/members/",
             headers=self.auth_headers
         )
         members_data = members_response.get_json()
@@ -547,7 +547,7 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Verify member was removed
         members_response = self.client.get(
-            f"/api/v1/circles/{parent_id}/members",
+            f"/api/v1/circles/{parent_id}/members/",
             headers=self.auth_headers
         )
         members_data = members_response.get_json()
@@ -587,7 +587,7 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
 
     def test_patch_circle_member_access(self):
-        """PATCH /circles/{circle_id}/members updates member access level."""
+        """PATCH /circles/{circle_id}/members/ updates member access level."""
         # Create two circles and add member relationship
         parent_id = self._create_test_circle(name="Parent Circle Patch")
         child_id = self._create_test_circle(name="Child Circle Patch")
@@ -604,7 +604,7 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Update the access level
         response = self.client.patch(
-            f"/api/v1/circles/{parent_id}/members",
+            f"/api/v1/circles/{parent_id}/members/",
             json={
                 "member_id": child_id,
                 "access_value": 10,
@@ -616,18 +616,18 @@ class TestApiCirclesContract(unittest.TestCase):
 
         # Verify access was updated
         members_response = self.client.get(
-            f"/api/v1/circles/{parent_id}/members",
+            f"/api/v1/circles/{parent_id}/members/",
             headers=self.auth_headers
         )
         members_data = members_response.get_json()
         self.assertEqual(members_data[child_id], 10)
 
     def test_patch_circle_member_requires_auth(self):
-        """PATCH /circles/{circle_id}/members without auth returns 401."""
+        """PATCH /circles/{circle_id}/members/ without auth returns 401."""
         circle_id = self._create_test_circle()
 
         response = self.client.patch(
-            f"/api/v1/circles/{circle_id}/members",
+            f"/api/v1/circles/{circle_id}/members/",
             json={
                 "member_id": "some-member-id",
                 "access_value": 10,
@@ -637,9 +637,9 @@ class TestApiCirclesContract(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_patch_member_for_missing_circle_returns_error(self):
-        """PATCH /circles/{circle_id}/members for non-existent circle returns 409."""
+        """PATCH /circles/{circle_id}/members/ for non-existent circle returns 409."""
         response = self.client.patch(
-            "/api/v1/circles/nonexistent_id/members",
+            "/api/v1/circles/nonexistent_id/members/",
             json={
                 "member_id": "some-member-id",
                 "access_value": 10,

--- a/tests/contract/api/test_api_submissions.py
+++ b/tests/contract/api/test_api_submissions.py
@@ -11,9 +11,9 @@ Submissions Endpoints Reference:
 - POST   /submissions/                              - Create a new submission
 - GET    /submissions/by-assignment/{assignment_id} - List submissions by assignment
 - GET    /submissions/by-student/{student_id}       - List submissions by student
-- GET    /submissions/{submission_id}               - Get a single submission
-- PATCH  /submissions/{submission_id}               - Update a submission
-- DELETE /submissions/{submission_id}               - Delete a submission
+- GET    /submissions/{submission_id}/              - Get a single submission
+- PATCH  /submissions/{submission_id}/              - Update a submission
+- DELETE /submissions/{submission_id}/              - Delete a submission
 - POST   /submissions/{submission_id}/responses     - Add a response to a submission
 - POST   /submissions/{submission_id}/feedback      - Add feedback to a submission (requires user context)
 - POST   /submissions/{submission_id}/submit        - Finalize/submit a submission
@@ -235,7 +235,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
         submission_id = self._create_test_submission()
 
         response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
 
@@ -248,7 +248,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
     def test_get_missing_submission_returns_error(self):
         """GET /submissions/{submission_id} for non-existent submission returns error."""
         response = self.client.get(
-            "/api/v1/submissions/nonexistent_id",
+            "/api/v1/submissions/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -262,7 +262,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
             {"question_id": "q1", "response_text": "Updated answer"},
         ]
         response = self.client.patch(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             json={"responses": new_responses},
             headers=self.auth_headers
         )
@@ -273,7 +273,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the update
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()
@@ -287,7 +287,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
             {"question_id": "q1", "feedback_text": "Good answer!", "teacher_id": str(self.user_id)},
         ]
         response = self.client.patch(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             json={"feedback": new_feedback},
             headers=self.auth_headers
         )
@@ -304,7 +304,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
         submitted_at = datetime.now(timezone.utc).isoformat()
 
         response = self.client.patch(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             json={"submitted_at": submitted_at},
             headers=self.auth_headers
         )
@@ -318,7 +318,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
         submission_id = self._create_test_submission()
 
         response = self.client.patch(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             json={},
             headers=self.auth_headers
         )
@@ -337,7 +337,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
         intentional (idempotent updates) or a bug.
         """
         response = self.client.patch(
-            "/api/v1/submissions/nonexistent_id",
+            "/api/v1/submissions/nonexistent_id/",
             json={"responses": [{"question_id": "q1", "response_text": "Answer"}]},
             headers=self.auth_headers
         )
@@ -352,7 +352,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
         submission_id = self._create_test_submission()
 
         response = self.client.delete(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
 
@@ -362,7 +362,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify it's deleted
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         self.assertIn(get_response.status_code, (404, 409))
@@ -370,7 +370,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
     def test_delete_missing_submission_returns_error(self):
         """DELETE /submissions/{submission_id} for non-existent submission returns error."""
         response = self.client.delete(
-            "/api/v1/submissions/nonexistent_id",
+            "/api/v1/submissions/nonexistent_id/",
             headers=self.auth_headers
         )
 
@@ -395,7 +395,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the response was added
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()
@@ -423,7 +423,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the response was updated (not duplicated)
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()
@@ -450,7 +450,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the feedback was added
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()
@@ -487,7 +487,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the feedback was updated (not duplicated)
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()
@@ -510,7 +510,7 @@ class TestApiSubmissionsContract(unittest.TestCase):
 
         # Verify the submission was marked as submitted
         get_response = self.client.get(
-            f"/api/v1/submissions/{submission_id}",
+            f"/api/v1/submissions/{submission_id}/",
             headers=self.auth_headers
         )
         submission_data = get_response.get_json()

--- a/tests/contract/auth/test_auth_users.py
+++ b/tests/contract/auth/test_auth_users.py
@@ -9,9 +9,9 @@ This is enforced via before_request hook in the auth blueprint.
 Users Endpoints Reference:
 - GET    /users/                    - List all users (requires auth)
 - POST   /users/                    - Create new user (requires auth)
-- GET    /users/{user_id}           - Get specific user (requires auth)
-- PATCH  /users/{user_id}           - Update user (requires auth, returns 501)
-- DELETE /users/{user_id}           - Delete user (requires auth)
+- GET    /users/{user_id}/          - Get specific user (requires auth)
+- PATCH  /users/{user_id}/          - Update user (requires auth, returns 501)
+- DELETE /users/{user_id}/          - Delete user (requires auth)
 - POST   /users/{user_id}/activate  - Activate a user (requires auth)
 """
 
@@ -126,7 +126,7 @@ class TestAuthUsersContract(unittest.TestCase):
         user_id = self._create_test_user("get.by.id@example.com", "Get By ID User")
 
         response = self.client.get(
-            f"/auth/v1/users/{user_id}",
+            f"/auth/v1/users/{user_id}/",
             headers=self.auth_headers
         )
 
@@ -151,7 +151,7 @@ class TestAuthUsersContract(unittest.TestCase):
         user_id = self._create_test_user("patch.test@example.com", "Patch Test User")
 
         response = self.client.patch(
-            f"/auth/v1/users/{user_id}",
+            f"/auth/v1/users/{user_id}/",
             json={"name": "Updated Name"},
             headers=self.auth_headers
         )
@@ -164,7 +164,7 @@ class TestAuthUsersContract(unittest.TestCase):
 
         # Delete the user
         del_response = self.client.delete(
-            f"/auth/v1/users/{user_id}",
+            f"/auth/v1/users/{user_id}/",
             json={},
             headers=self.auth_headers
         )
@@ -172,7 +172,7 @@ class TestAuthUsersContract(unittest.TestCase):
 
         # Verify it's gone
         get_response = self.client.get(
-            f"/auth/v1/users/{user_id}",
+            f"/auth/v1/users/{user_id}/",
             headers=self.auth_headers
         )
         self.assertIn(get_response.status_code, (404, 400))
@@ -184,7 +184,7 @@ class TestAuthUsersContract(unittest.TestCase):
 
         # Delete without JSON body
         del_response = self.client.delete(
-            f"/auth/v1/users/{user_id}",
+            f"/auth/v1/users/{user_id}/",
             headers=self.auth_headers
         )
         # unpack_request decorator requires JSON


### PR DESCRIPTION
## Summary
Standardize URL patterns across all API endpoints to follow the documented trailing slash convention.

## Changes
- **Server-side**: Add trailing slashes to 14 single resource endpoints across circles, assignments, submissions, and users routes
- **Test updates**: Update all test URLs to match new server patterns
- **Pattern compliance**: Ensure consistency with documented URL schema in `docs/campus-api-schema.md`

## Details
This fix prevents redirect issues between clients and servers by standardizing:
- ✅ Resource roots (`/api/v1/`, `/auth/v1/`) - have trailing slashes
- ✅ Resource collections (`/circles/`, `/assignments/`) - have trailing slashes  
- ✅ Single resources (`/circles/{id}/`, `/assignments/{id}/`) - have trailing slashes
- ✅ Dead-end subresources (`/timetable/current`, `/traces/search`) - no trailing slashes

## Testing
- All route files compile successfully
- URL pattern verification passed for all modified routes
- No test regressions detected
- Sanity checks passed

## Related
- Documents URL pattern: `docs/campus-api-schema.md`
- Fixes violations identified in API schema audit

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>