### PR TITLE
refactor(audit): improve audit event architecture and documentation

### DIFF
--- a/campus/audit/helpers/audit_events.py
+++ b/campus/audit/helpers/audit_events.py
@@ -210,8 +210,19 @@ def audit_event(
     - Duration, API key ID, parent span ID
     - Client IP and user agent
 
-    Only emits events for 2XX and 3XX responses. Error responses are
-    captured from error handler output via flask.after_this_request.
+    ## Error Handling Architecture
+
+    This decorator uses `flask.after_this_request()` to capture the **final**
+    response after all error handlers have executed. This means:
+
+    1. Route function runs → may raise exception
+    2. Error handler catches → converts exception to HTTP response (e.g., 400, 500)
+    3. `after_this_request` callback runs → sees the **final response** from error handler
+    4. Audit event emitted with full error context
+
+    **Key insight:** The decorator sees BOTH success responses (2XX/3XX) AND
+    error responses (4XX/5XX) because it hooks into the response pipeline
+    after error handlers run.
 
     Args:
         event_type: Event type (e.g., "audit.apikeys.new")
@@ -256,24 +267,24 @@ def audit_event(
                 duration_ms = _calculate_duration_ns(request_start_ns, units="ms")
                 status_code = response.status_code
 
-                # Only emit audit events for 2XX and 3XX responses
-                if 200 <= status_code < 400:
-                    event_data = {
-                        "endpoint": flask.request.endpoint,
-                        "method": flask.request.method,
-                        "path": flask.request.path,
-                        "status_code": status_code,
-                    }
+                # Emit audit events for ALL responses (success and error)
+                # Error handlers have already run, so 4XX/5XX responses are captured
+                event_data = {
+                    "endpoint": flask.request.endpoint,
+                    "method": flask.request.method,
+                    "path": flask.request.path,
+                    "status_code": status_code,
+                }
 
-                    emit_from_flask(
-                        flask.request,
-                        response,
-                        event_type=event_type,
-                        data=event_data,
-                        api_key_id=flask.g.api_key_id,
-                        started_at=started_at,
-                        duration_ms=duration_ms,
-                    )
+                emit_from_flask(
+                    flask.request,
+                    response,
+                    event_type=event_type,
+                    data=event_data,
+                    api_key_id=flask.g.api_key_id,
+                    started_at=started_at,
+                    duration_ms=duration_ms,
+                )
 
                 event_emitted = True
                 return response

--- a/campus/audit/resources/apikeys.py
+++ b/campus/audit/resources/apikeys.py
@@ -113,7 +113,7 @@ class APIKeysResource:
                 f"{api_key.to_resource()}"
             )
         else:
-            # TODO: Log audit event for campus.apikeys.new (see #567)
+            # Audit event logged at routes layer (campus/audit/routes/apikeys.py)
             # Note: No actor tracking - campus.audit is standalone service with no users/clients
             return api_key, apikey_value
 
@@ -191,7 +191,7 @@ class APIKeyResource:
                 f"API key {self.api_key_id} not found"
             ) from None
         else:
-            # TODO: Log audit event for campus.apikeys.regenerate (see #567)
+            # Audit event logged at routes layer (campus/audit/routes/apikeys.py)
             # Note: No actor tracking - campus.audit is standalone service with no users/clients
             return new_key
 
@@ -205,7 +205,7 @@ class APIKeyResource:
         except storage_errors.NotFoundError:
             return False
         else:
-            # TODO: Log audit event for campus.apikeys.revoke (see #567)
+            # Audit event logged at routes layer (campus/audit/routes/apikeys.py)
             # Note: No actor tracking - campus.audit is standalone service with no users/clients
             return True
 
@@ -234,5 +234,5 @@ class APIKeyResource:
                 f"API key {self.api_key_id} not found"
             ) from None
 
-        # TODO: Log audit event for campus.apikeys.update (see #567)
+        # Audit event logged at routes layer (campus/audit/routes/apikeys.py)
         # Note: No actor tracking - campus.audit is standalone service with no users/clients

--- a/campus/audit/routes/traces.py
+++ b/campus/audit/routes/traces.py
@@ -21,10 +21,9 @@ bp = flask.Blueprint('audit_traces', __name__, url_prefix='/traces')
 
 @bp.post("/")
 @flask_campus.unpack_request
-@audit_events.audit_event("audit.traces.ingest")
 def ingest_spans(
-    *,
-    spans: list[dict[str, Any]],
+        *,
+        spans: list[dict[str, Any]],
 ) -> flask_campus.JsonResponse:
     """Ingest trace spans (batch or single).
 
@@ -65,6 +64,12 @@ def ingest_spans(
         207 Multi-Status on partial failure
         400 Bad Request on invalid input
     """
+    from campus.common import schema
+    import time
+
+    started_at = schema.DateTime.utcnow()
+    start_ns = time.perf_counter_ns()
+
     # Convert dicts to TraceSpan models with validation
     import campus.model as model
     try:
@@ -73,9 +78,54 @@ def ingest_spans(
             for span_dict in spans
         ]
     except (KeyError, TypeError, ValueError) as e:
+        # Emit failed audit event for invalid input
+        duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+        request_context = audit_events._extract_request_context(flask.request)
+
+        # Create minimal response context for error
+        response_context: audit_events.FlaskResponseContext = {
+            "status_code": 400,
+            "headers": {},
+            "body": {},
+        }
+
+        audit_events.emit_audit_event(
+            data={
+                "event_type": "audit.traces.ingest.failed",
+                "error": str(e),
+                "span_count": len(spans),
+            },
+            api_key_id=flask.g.get("api_key_id"),
+            parent_span_id=flask.g.get("span_id"),
+            started_at=started_at,
+            duration_ms=duration_ms,
+            request_context=request_context,
+            response_context=response_context,
+        )
         raise api_errors.InvalidRequestError(f"Invalid span data: {e}")
 
     result = traces_resource.ingest(span_models)
+
+    # Emit success audit event for successful ingestions
+    duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
+    request_context = audit_events._extract_request_context(flask.request)
+    response_context = audit_events._extract_response_context(
+        flask.make_response(result, 201)
+    )
+
+    audit_events.emit_audit_event(
+        data={
+            "event_type": "audit.traces.ingest.success",
+            "span_count": len(span_models),
+        },
+        api_key_id=flask.g.get("api_key_id"),
+        parent_span_id=flask.g.get("span_id"),
+        started_at=started_at,
+        duration_ms=duration_ms,
+        request_context=request_context,
+        response_context=response_context,
+    )
+
     return result, 201
 
 
@@ -83,10 +133,10 @@ def ingest_spans(
 @flask_campus.unpack_request
 @audit_events.audit_event("audit.traces.list")
 def list_traces(
-    *,
-    since: str | None = None,
-    until: str | None = None,
-    limit: str | int = 50,
+        *,
+        since: str | None = None,
+        until: str | None = None,
+        limit: str | int = 50,
 ) -> flask_campus.JsonResponse:
     """List recent traces, newest first.
 
@@ -175,15 +225,15 @@ def get_span(trace_id: str, span_id: str) -> flask_campus.JsonResponse:
 @flask_campus.unpack_request
 @audit_events.audit_event("audit.traces.search")
 def search_traces(
-    *,
-    path: str | None = None,
-    status: str | int | None = None,
-    api_key_id: str | None = None,
-    client_id: str | None = None,
-    user_id: str | None = None,
-    since: str | None = None,
-    until: str | None = None,
-    limit: str | int = 50,
+        *,
+        path: str | None = None,
+        status: str | int | None = None,
+        api_key_id: str | None = None,
+        client_id: str | None = None,
+        user_id: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: str | int = 50,
 ) -> flask_campus.JsonResponse:
     """Filter and search traces.
 

--- a/campus/audit/routes/traces.py
+++ b/campus/audit/routes/traces.py
@@ -21,6 +21,7 @@ bp = flask.Blueprint('audit_traces', __name__, url_prefix='/traces')
 
 @bp.post("/")
 @flask_campus.unpack_request
+@audit_events.audit_event("audit.traces.ingest")
 def ingest_spans(
         *,
         spans: list[dict[str, Any]],
@@ -63,13 +64,14 @@ def ingest_spans(
         201 Created with span IDs on success
         207 Multi-Status on partial failure
         400 Bad Request on invalid input
+
+    Note:
+        Audit events are emitted for both successful ingestions (201/207)
+        and validation failures (400) via the @audit_event decorator.
+        The decorator uses flask.after_this_request to capture the final
+        response after error handlers run, so failed ingestions are logged
+        with error details.
     """
-    from campus.common import schema
-    import time
-
-    started_at = schema.DateTime.utcnow()
-    start_ns = time.perf_counter_ns()
-
     # Convert dicts to TraceSpan models with validation
     import campus.model as model
     try:
@@ -78,54 +80,9 @@ def ingest_spans(
             for span_dict in spans
         ]
     except (KeyError, TypeError, ValueError) as e:
-        # Emit failed audit event for invalid input
-        duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-        request_context = audit_events._extract_request_context(flask.request)
-
-        # Create minimal response context for error
-        response_context: audit_events.FlaskResponseContext = {
-            "status_code": 400,
-            "headers": {},
-            "body": {},
-        }
-
-        audit_events.emit_audit_event(
-            data={
-                "event_type": "audit.traces.ingest.failed",
-                "error": str(e),
-                "span_count": len(spans),
-            },
-            api_key_id=flask.g.get("api_key_id"),
-            parent_span_id=flask.g.get("span_id"),
-            started_at=started_at,
-            duration_ms=duration_ms,
-            request_context=request_context,
-            response_context=response_context,
-        )
         raise api_errors.InvalidRequestError(f"Invalid span data: {e}")
 
     result = traces_resource.ingest(span_models)
-
-    # Emit success audit event for successful ingestions
-    duration_ms = (time.perf_counter_ns() - start_ns) / 1_000_000
-    request_context = audit_events._extract_request_context(flask.request)
-    response_context = audit_events._extract_response_context(
-        flask.make_response(result, 201)
-    )
-
-    audit_events.emit_audit_event(
-        data={
-            "event_type": "audit.traces.ingest.success",
-            "span_count": len(span_models),
-        },
-        api_key_id=flask.g.get("api_key_id"),
-        parent_span_id=flask.g.get("span_id"),
-        started_at=started_at,
-        duration_ms=duration_ms,
-        request_context=request_context,
-        response_context=response_context,
-    )
-
     return result, 201
 
 

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -284,6 +284,59 @@ class SMTPSender(EmailSender):
 - Easier testing with mock implementations
 - Clear contracts between components
 
+### Audit Event Logging
+
+Audit events provide a comprehensive trail of all operations in the audit service.
+The `@audit_event` decorator automatically captures request/response context for
+both successful operations and errors.
+
+#### How It Works
+
+The decorator uses `flask.after_this_request()` to capture the **final response**
+after error handlers have executed:
+
+```python
+from campus.audit.helpers import audit_events
+
+@bp.post("/apikeys")
+@audit_events.audit_event("audit.apikeys.new")
+def create_apikey(**kwargs):
+    # May raise api_errors.InvalidRequestError
+    return apikey, 201
+
+# Flow:
+# 1. Route function runs → raises InvalidRequestError
+# 2. Error handler catches → returns 400 response
+# 3. after_this_request callback runs → sees 400 response
+# 4. Audit event emitted with status_code=400
+```
+
+#### Key Architectural Points
+
+1. **Error handlers run before the callback** - The decorator sees the final
+   HTTP response (400, 500, etc.) not the original exception.
+
+2. **All responses are logged** - Both successful (2XX/3XX) and error (4XX/5XX)
+   responses are captured automatically.
+
+3. **Context is captured automatically** - Request headers, body, client IP,
+   user agent, response status, timing, and API key ID are included.
+
+4. **No manual error handling needed** - Don't catch exceptions just to log them.
+   The decorator handles both success and failure paths.
+
+#### When to Use
+
+- **Route functions** - Use `@audit_event` for all HTTP endpoints
+- **Authentication** - Use for auth success/failure events
+- **CRUD operations** - Use for create, update, delete operations
+
+#### When NOT to Use
+
+- **Background jobs** - Use `emit_audit_event()` directly
+- **Custom event types** - If you need different event types for success vs failure,
+  use manual calls to `emit_audit_event()`
+
 ## Common Pitfalls
 
 ### Storage Initialization Order


### PR DESCRIPTION
## Summary

Improves audit event architecture by using the `@audit_event` decorator consistently
and adds comprehensive documentation to prevent future confusion about error handling.

## Changes

### Consistent Decorator Usage (commit 8cfa494)

**Before:** Manual `emit_audit_event()` calls in `ingest_spans()`  
**After:** All routes use `@audit_event` decorator consistently

**Benefits:**
- **Consistent code** - All routes follow the same pattern
- **Error logging** - 400/500 responses now captured automatically
- **Simpler implementation** - Fewer lines, less complexity
- **Better maintainability** - Single source of truth for audit events

### Enhanced Error Handling

The decorator now logs **ALL responses** (not just 2XX/3XX):
- ✅ 201/207 - Successful ingestions
- ✅ 400 - Validation errors (e.g., invalid span data)
- ✅ 404 - Not found errors
- ✅ 500 - Server errors

This works because `flask.after_this_request()` captures the **final response**
after error handlers have executed.

### Documentation Improvements

**1. Decorator Docstring** (`campus/audit/helpers/audit_events.py`)
- Added "Error Handling Architecture" section
- Explains the request/response flow
- Clarifies when error handlers run vs when audit events emit
- Prevents future mistakes (like manual error handling)

**2. Architectural Documentation** (`docs/development-guidelines.md`)
- New "Audit Event Logging" section
- Code examples showing error handling flow
- When to use decorator vs manual `emit_audit_event()`
- Key architectural principles

## Example

```python
@bp.post("/")
@audit_events.audit_event("audit.traces.ingest")
def ingest_spans(*, spans: list[dict]):
    # Raises InvalidRequestError on validation failure
    # Error handler converts to 400 response
    # Decorator captures 400 response and logs it
    return result, 201
```

## Test Results

- ✅ 214/214 unit tests passing
- ✅ Type checks passing (Pyright)
- ✅ Sanity checks passing

## Related

- Issue: #567 (Audit Trail Logging)
- Previous PR: #577 (Initial audit trail implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)