### PR TITLE
fix(oauth): set Flask session in Google callback, require login for device verification

### DIFF
--- a/campus/auth/oauth_proxy/google/proxy.py
+++ b/campus/auth/oauth_proxy/google/proxy.py
@@ -194,18 +194,20 @@ class GoogleAuthProxy(base.AuthProxy):
         # Finalize authsession and get credentials
         credentials = self.handle_auth_callback(state, code, scope)
 
+        # Set Flask session for subsequent requests
+        session = flask.session
+        session['user_id'] = str(credentials.user_id)
+
         # Parse target URL and preserve existing query params (like state)
         from urllib.parse import urlparse, parse_qs
         target_url = authsession.target or flask.request.host_url
         parsed = urlparse(target_url)
         existing_params = parse_qs(parsed.query)
 
-        # Merge existing params with new user param
+        # Merge existing params (without user param - now in session)
         redirect_params = {**{k: v[0] for k, v in existing_params.items()}}
-        redirect_params['user'] = credentials.user_id
 
-        # Pass authenticated user_id to target URL
-        # Target app is expected to verify valid Google credential
+        # Redirect to target URL - user_id is now in the session
         redirect_url = url.add_query(
             f"{parsed.scheme}://{parsed.netloc}{parsed.path}",
             **redirect_params

--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -352,31 +352,24 @@ def device_verification(user_code: str | None = None):
     GET /device?status=error&error_code=expired - Shows error state (for no-JS fallback)
     POST /device - Handles form submission for non-JS clients
     """
-    from flask import render_template_string, request, redirect, session, url_for
+    from flask import render_template_string, request, redirect, session
     import html
 
     # Check if user is authenticated (for both GET and POST)
-    # First check Flask session, then check query param (from Google OAuth callback)
+    # User must be logged in to authorize a device code
     user_id = session.get('user_id')
     if not user_id:
-        # Check if user_id is in query params (from Google OAuth callback)
-        user_param = request.args.get('user')
-        if user_param:
-            # Set the session for subsequent requests
-            session['user_id'] = user_param
-            user_id = user_param
-        else:
-            # User not logged in - redirect to Google OAuth login
-            # After login, they'll return to this page to authorize the device
-            login_callback = url_for('auth.oauth.device_verification', _external=True)
-            if user_code:
-                login_callback += f"/{user_code}"
-            oauth_authorize_url = url_for(
-                'auth.google.authorize',
-                _external=True,
-                target=login_callback
-            )
-            return redirect(oauth_authorize_url)
+        # User not logged in - redirect to Google OAuth login
+        # After login, they'll return to this page to authorize the device
+        login_callback = flask.url_for('auth.oauth.device_verification', _external=True)
+        if user_code:
+            login_callback += f"/{user_code}"
+        oauth_authorize_url = flask.url_for(
+            'auth.google.authorize',
+            _external=True,
+            target=login_callback
+        )
+        return flask.redirect(oauth_authorize_url)
 
     # Handle POST for non-JS fallback
     if request.method == "POST":

--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -229,6 +229,11 @@ def _handle_device_code_grant(
         raise token_errors.InvalidGrantError(
             "Invalid or expired device code"
         )
+    except api_errors.InvalidRequestError:
+        # Device code has expired
+        raise token_errors.ExpiredTokenError(
+            "The device code has expired"
+        )
 
     # Check the state of the device code
     if dc.state == "pending":

--- a/tests/integration/auth/test_oauth_routes.py
+++ b/tests/integration/auth/test_oauth_routes.py
@@ -5,6 +5,7 @@ with both JSON and form-encoded requests per RFC 8628.
 """
 
 import unittest
+from unittest import mock
 
 from tests.integration.base import IntegrationTestCase
 
@@ -126,11 +127,14 @@ class TestOAuthIntegration(IntegrationTestCase):
 
         self.assertEqual(token_response.status_code, 400)
         token_data = token_response.get_json()
-        # Campus returns structured errors, check for authorization_pending in details
+        # OAuth errors use Campus envelope format (for API consistency)
         self.assertIn("error", token_data)
-        # The error code should indicate authorization is pending
-        error_code = token_data.get("error", {}).get("code", "")
-        self.assertIn("PENDING", error_code)
+        error_obj = token_data.get("error", {})
+        # Check Campus error code contains PENDING
+        self.assertIn("PENDING", error_obj.get("code", ""))
+        # Also verify the OAuth error in details
+        oauth_error = error_obj.get("details", {}).get("oauth_error", "")
+        self.assertEqual(oauth_error, "authorization_pending")
 
     def test_oauth_verification_page(self):
         """Test the device verification page redirects unauthenticated users to login."""
@@ -140,6 +144,231 @@ class TestOAuthIntegration(IntegrationTestCase):
         self.assertEqual(response.status_code, 302)
         # Redirect should go to Google OAuth authorize endpoint
         self.assertIn("google", response.location.lower())
+
+    def test_device_verification_requires_authentication(self):
+        """Test that device verification endpoint requires authentication."""
+        # Without session - should redirect to login
+        response = self.client.get("/auth/v1/oauth/device")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("google", response.location.lower())
+
+        # With session - should show form
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = 'test@example.com'
+
+            response = client.get("/auth/v1/oauth/device")
+            self.assertEqual(response.status_code, 200)
+            # Should contain the device verification form
+            self.assertIn("Enter User Code", response.get_data(as_text=True))
+
+    def test_user_query_parameter_ignored(self):
+        """Test that user query parameter is ignored (security fix)."""
+        # Try to access with user query parameter (old insecure method)
+        response = self.client.get("/auth/v1/oauth/device?user=attacker@example.com")
+
+        # Should still redirect to login, not trust the query param
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("google", response.location.lower())
+
+        # Session should NOT be set
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                self.assertNotIn('user_id', sess)
+
+    def test_device_code_state_transitions(self):
+        """Test device code state transitions: pending -> authorized -> consumed."""
+        # 1. Create device code (state: pending)
+        create_response = self.client.post(
+            "/auth/v1/oauth/device_authorize",
+            data={"client_id": "guest"},
+            content_type="application/x-www-form-urlencoded"
+        )
+        create_data = create_response.get_json()
+        device_code = create_data["device_code"]
+        user_code = create_data["user_code"]
+
+        # 2. Poll while pending -> returns authorization_pending
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 400)
+        # OAuth errors use Campus envelope format (for API consistency)
+        error_data = token_response.get_json()
+        error_obj = error_data.get("error", {})
+        oauth_error = error_obj.get("details", {}).get("oauth_error", "")
+        self.assertEqual(oauth_error, "authorization_pending")
+
+        # 3. Authorize the device code (state: authorized)
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = 'test@example.com'
+
+            # Get the user to authorize
+            authorize_response = client.post(
+                "/auth/v1/oauth/device/authorize",
+                json={"user_code": user_code, "user_id": "test@example.com"}
+            )
+            self.assertEqual(authorize_response.status_code, 200)
+
+        # 4. Poll again -> returns token (state: consumed)
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 200)
+        token_data = token_response.get_json()
+        self.assertIn("access_token", token_data)
+
+        # 5. Try to use same device code again -> error (already consumed)
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 400)
+        # OAuth errors use Campus envelope format (for API consistency)
+        error_data = token_response.get_json()
+        error_obj = error_data.get("error", {})
+        # Check for INVALID in Campus error code
+        self.assertIn("INVALID", error_obj.get("code", ""))
+        # Also verify the OAuth error in details
+        oauth_error = error_obj.get("details", {}).get("oauth_error", "")
+        self.assertEqual(oauth_error, "invalid_grant")
+
+    def test_device_code_invalid(self):
+        """Test that invalid device codes are rejected."""
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": "invalid_device_code_12345",
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 400)
+        error_data = token_response.get_json()
+        self.assertIn("error", error_data)
+        # Check for INVALID in Campus error code
+        error_obj = error_data.get("error", {})
+        self.assertIn("INVALID", error_obj.get("code", ""))
+
+    def test_device_code_expired(self):
+        """Test that expired device codes are rejected.
+
+        NOTE: This test uses time mocking which is unusual in this codebase.
+        Mocking is necessary here because device codes have a time-based expiry
+        (default 600 seconds) and we need to test the expiry behavior without
+        waiting 10 minutes. Alternative would be to manually insert an expired
+        device code into the database, but that would be testing database
+        internals rather than the OAuth flow behavior.
+        """
+        import campus.config
+        from campus.common.utils import utc_time
+        from datetime import timedelta
+
+        expiry_seconds = campus.config.DEFAULT_DEVICE_CODE_EXPIRY_SECONDS
+
+        # Create a device code in the "past" by mocking time during creation
+        # The device code's expires_at will be set based on the mocked time
+        past_time = utc_time.now() - timedelta(seconds=expiry_seconds + 1)
+
+        with mock.patch('campus.common.utils.utc_time.now', return_value=past_time):
+            # Create device code (will have expires_at in the past relative to real time)
+            create_response = self.client.post(
+                "/auth/v1/oauth/device_authorize",
+                data={"client_id": "guest"},
+                content_type="application/x-www-form-urlencoded"
+            )
+            create_data = create_response.get_json()
+            device_code = create_data["device_code"]
+
+        # Now try to exchange the device code (without mock - real time is used)
+        # Since the device code was created with a past time, it should be expired
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 400)
+        # OAuth errors use Campus envelope format (for API consistency)
+        error_data = token_response.get_json()
+        self.assertIn("error", error_data)
+        error_obj = error_data.get("error", {})
+        # Check for EXPIRED in Campus error code
+        self.assertIn("EXPIRED", error_obj.get("code", ""))
+        # Also verify the OAuth error in details
+        oauth_error = error_obj.get("details", {}).get("oauth_error", "")
+        self.assertEqual(oauth_error, "expired_token")
+
+    def test_device_code_already_used(self):
+        """Test that already-used device codes are rejected."""
+        # Create a device code
+        create_response = self.client.post(
+            "/auth/v1/oauth/device_authorize",
+            data={"client_id": "guest"},
+            content_type="application/x-www-form-urlencoded"
+        )
+        create_data = create_response.get_json()
+        device_code = create_data["device_code"]
+        user_code = create_data["user_code"]
+
+        # Authorize it
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = 'test@example.com'
+
+            authorize_response = client.post(
+                "/auth/v1/oauth/device/authorize",
+                json={"user_code": user_code, "user_id": "test@example.com"}
+            )
+            self.assertEqual(authorize_response.status_code, 200)
+
+        # Get token
+        token_response = self.client.post(
+            "/auth/v1/oauth/token",
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                "device_code": device_code,
+                "client_id": "guest",
+            },
+            content_type="application/x-www-form-urlencoded"
+        )
+        self.assertEqual(token_response.status_code, 200)
+
+        # Try to authorize again (should fail - already consumed/deleted)
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = 'test@example.com'
+
+            authorize_response = client.post(
+                "/auth/v1/oauth/device/authorize",
+                json={"user_code": user_code, "user_id": "test@example.com"}
+            )
+            # Device code is deleted after token exchange, so we get 404
+            self.assertEqual(authorize_response.status_code, 404)
+            error_data = authorize_response.get_json()
+            self.assertIn("error", error_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Google OAuth callback now sets Flask session directly instead of passing user_id as query parameter
- Device verification endpoint now requires login before showing the form
- Fixes session fixation vulnerability and improves UX

## Changes
1. **Google OAuth callback** (`campus/auth/oauth_proxy/google/proxy.py`)
   - Sets `session['user_id']` directly after successful authentication
   - Removes insecure `user` query parameter from redirect

2. **Device verification** (`campus/auth/routes/oauth.py`)
   - Requires login before showing device authorization form
   - Removes code that blindly trusted `user` query parameter

## Security
- Previously, the `user` query parameter could be manipulated
- Now, user_id is only set in session by legitimate Google OAuth callback

## Test plan
- [ ] Test device authorization flow with campus-cli
- [ ] Verify unauthenticated users are redirected to Google OAuth
- [ ] Verify authenticated users can authorize device codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)