### PR TITLE
fix(deploy): add ProxyFix middleware for correct redirect URLs

### DIFF
--- a/campus/common/devops/deploy.py
+++ b/campus/common/devops/deploy.py
@@ -7,6 +7,7 @@ application.
 from typing import Protocol, runtime_checkable
 
 import flask
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 from campus.common import devops, env, introspect
 import campus.common.errors
@@ -137,6 +138,17 @@ def create_app(*appmodules: AppModule) -> flask.Flask:
     for module in appmodules:
         module.init_app(app)
     campus.common.errors.init_app(app)
+
+    # Fix scheme/redirect issues when behind reverse proxy (Railway, Nginx, etc.)
+    # Railway sends X-Forwarded-Proto, X-Forwarded-Host, X-Forwarded-For headers
+    # ProxyFix ensures Flask url_for() generates correct https URLs
+    app.wsgi_app = ProxyFix(
+        app.wsgi_app,
+        x_for=1,          # X-Forwarded-For (client IP)
+        x_proto=1,        # X-Forwarded-Proto (scheme) <-- fixes http/https
+        x_host=1,         # X-Forwarded-Host (original host)
+        x_prefix=1,       # X-Forwarded-Prefix (if using subpaths)
+    )
 
     # Register tracing middleware for auth/api deployments
     # campus.audit handles ingestion but doesn't trace its own requests


### PR DESCRIPTION
## Summary

When running behind a reverse proxy (Railway, Nginx, etc.), Flask's `url_for(..., _external=True)` was generating HTTP URLs instead of HTTPS, causing redirect scheme mismatch issues.

This commit adds `werkzeug.middleware.proxy_fix.ProxyFix` to handle `X-Forwarded-*` headers sent by Railway:
- `X-Forwarded-Proto`: sets correct URL scheme (https vs http)
- `X-Forwarded-Host`: preserves original host
- `X-Forwarded-For`: passes through client IP
- `X-Forwarded-Prefix`: handles subpath routing

This ensures OAuth redirect URLs use the correct HTTPS scheme, fixing login flows and other redirects in production deployment.

## Test plan

- [x] Local tests pass (ProxyFix is transparent in local dev)
- [ ] Deploy to Railway and verify OAuth redirects use HTTPS
- [ ] Test device authorization flow end-to-end
- [ ] Verify other redirects (login, callbacks) use correct scheme

## Investigation notes

The OAuth redirect codepath was working correctly (tests pass, 302 redirect happens), but the generated redirect URL used `http` instead of `https`. This is a common issue when Flask runs behind a reverse proxy that terminates SSL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)