### PR TITLE
Fix OAuth device verification JavaScript to use correct service endpoints

### DIFF
--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -742,7 +742,8 @@ def device_verification(user_code: str | None = None):
                 }
 
                 // Check if user is logged in
-                const response = await fetch('/api/v1/users/me', {
+                // Use relative path since /users/me is now under /oauth/
+                const response = await fetch('./users/me', {
                     method: 'GET',
                     credentials: 'include'
                 });
@@ -765,7 +766,7 @@ def device_verification(user_code: str | None = None):
                 submitBtn.innerHTML = 'Processing <span class="spinner"></span>';
 
                 try {
-                    const authResponse = await fetch('/api/v1/oauth/device/authorize', {
+                    const authResponse = await fetch('./authorize', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -989,6 +990,26 @@ def device_authorize_submit(
     return {"success": True}, 200
 
 
+@bp.get("/users/me")
+def users_me() -> flask_campus.JsonResponse:
+    """Get the current authenticated user from session.
+
+    GET /oauth/users/me
+    Returns: User
+
+    This endpoint is used by the device verification page to check if
+    the user is authenticated. It returns the user from the Flask session
+    without requiring additional authentication headers.
+    """
+    user_id = flask.session.get('user_id')
+    if not user_id:
+        raise api_errors.UnauthorizedError(
+            "Not authenticated",
+            error_code="NOT_AUTHENTICATED"
+        )
+    return {"user": {"id": str(user_id)}}, 200
+
+
 def create_blueprint() -> flask.Blueprint:
     """Create a fresh blueprint with OAuth routes for test isolation.
 
@@ -1003,5 +1024,6 @@ def create_blueprint() -> flask.Blueprint:
     new_bp.add_url_rule("/device", "device_verification", device_verification, methods=["GET", "POST"])
     new_bp.add_url_rule("/device/<user_code>", "device_verification_prefilled", device_verification, methods=["GET", "POST"])
     new_bp.add_url_rule("/device/authorize", "device_authorize_submit", device_authorize_submit, methods=["POST"])
+    new_bp.add_url_rule("/users/me", "users_me", users_me, methods=["GET"])
 
     return new_bp

--- a/tests/integration/auth/test_oauth_routes.py
+++ b/tests/integration/auth/test_oauth_routes.py
@@ -370,6 +370,23 @@ class TestOAuthIntegration(IntegrationTestCase):
             error_data = authorize_response.get_json()
             self.assertIn("error", error_data)
 
+    def test_users_me_endpoint_returns_current_user_from_session(self):
+        """Test that /oauth/users/me returns the current user from Flask session."""
+        # Test without session - should return 401
+        response = self.client.get("/auth/v1/oauth/users/me")
+        self.assertEqual(response.status_code, 401)
+
+        # Test with session - should return user data
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['user_id'] = 'test@example.com'
+
+            response = client.get("/auth/v1/oauth/users/me")
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+            self.assertIn("user", data)
+            self.assertEqual(data["user"]["id"], "test@example.com")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
The device verification page (served by campus.auth) was making JavaScript fetch requests to `/api/v1/users/me` and `/api/v1/oauth/device/authorize`. These paths route to campus.api service (different domain), so the Flask session cookie from campus.auth wasn't being sent, causing authentication checks to fail after Google OAuth login.

## Changes
- Add `/oauth/users/me` endpoint in campus.auth that returns current user from Flask session (no bearer token required)
- Change JavaScript fetch URLs to use relative paths (`./users/me` and `./authorize`) to keep requests within campus.auth service
- Add test for the new `/oauth/users/me` endpoint

## Fixes
Fixes issue where device authorization showed "You must be logged in to authorize a device" error immediately after successful Google authentication when using `campus auth login` CLI command.

## Test Plan
- [x] All 11 OAuth integration tests pass
- [x] New test for `/oauth/users/me` endpoint passes
- [ ] Manual testing of OAuth device flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)