### PR TITLE
fix: correct relative path for device authorize endpoint

### DIFF
--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -766,7 +766,7 @@ def device_verification(user_code: str | None = None):
                 submitBtn.innerHTML = 'Processing <span class="spinner"></span>';
 
                 try {
-                    const authResponse = await fetch('./authorize', {
+                    const authResponse = await fetch('./device/authorize', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

The JavaScript fetch was using `./authorize` which resolves to `/auth/v1/oauth/authorize` (404), but the actual endpoint is `/auth/v1/oauth/device/authorize`.

## Changes

Changed relative path from `./authorize` to `./device/authorize` to correctly hit the device authorization submit endpoint.

## Fixes

Fixes 404 error when attempting to authorize a device code after Google OAuth login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)