### PR TITLE
feat: add ne (not equal) query operator

### DIFF
--- a/campus/storage/__init__.py
+++ b/campus/storage/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "gte",
     "lt",
     "lte",
+    "ne",
     "between",
     "is_operator",
 ]
@@ -46,7 +47,7 @@ from .errors import (
     NotFoundError,
     NoChangesAppliedError
 )
-from .query import gt, gte, lt, lte, between, is_operator
+from .query import gt, gte, lt, lte, ne, between, is_operator
 
 
 def get_table(name: str) -> TableInterface:

--- a/campus/storage/documents/backend/memory.py
+++ b/campus/storage/documents/backend/memory.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List
 from campus.common import devops
 from campus.model import Model
 from campus.storage.documents.interface import CollectionInterface, PK
-from campus.storage.query import gt, gte, is_operator, lt, lte
+from campus.storage.query import gt, gte, is_operator, lt, lte, ne
 
 
 class MemoryCollection(CollectionInterface):
@@ -79,7 +79,7 @@ class MemoryCollection(CollectionInterface):
     ) -> List[Dict[str, Any]]:
         """Retrieve documents matching a query.
 
-        Supports exact matches, comparison operators (gt, gte, lt, lte),
+        Supports exact matches, comparison operators (gt, gte, lt, lte, ne),
         sorting, and pagination.
         """
         collection = self._get_collection()
@@ -114,7 +114,7 @@ class MemoryCollection(CollectionInterface):
     def _matches_query(self, doc: Dict[str, Any], query: Dict[str, Any]) -> bool:
         """Check if a document matches a query.
 
-        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        Handles exact matches and comparison operators (gt, gte, lt, lte, ne).
         """
         for key, value in query.items():
             if key not in doc:
@@ -135,6 +135,9 @@ class MemoryCollection(CollectionInterface):
                         return False
                 elif isinstance(value, lte):
                     if not (doc_value <= value.value):
+                        return False
+                elif isinstance(value, ne):
+                    if not (doc_value != value.value):
                         return False
                 else:
                     # Unknown operator, fall back to exact match

--- a/campus/storage/documents/backend/mongodb.py
+++ b/campus/storage/documents/backend/mongodb.py
@@ -41,7 +41,7 @@ from campus.storage.errors import (
     NotFoundError,
     StorageError
 )
-from campus.storage.query import gt, gte, is_operator, lt, lte
+from campus.storage.query import gt, gte, is_operator, lt, lte, ne
 
 JsonObject = dict[str, Any]
 
@@ -163,6 +163,7 @@ class MongoDBCollection(CollectionInterface):
         - gte(value) → {"field": {"$gte": value}}
         - lt(value) → {"field": {"$lt": value}}
         - lte(value) → {"field": {"$lte": value}}
+        - ne(value) → {"field": {"$ne": value}}
         - exact match → {"field": value}
         """
         mongo_query = {}
@@ -176,6 +177,8 @@ class MongoDBCollection(CollectionInterface):
                     mongo_query[key] = {"$lt": value.value}
                 elif isinstance(value, lte):
                     mongo_query[key] = {"$lte": value.value}
+                elif isinstance(value, ne):
+                    mongo_query[key] = {"$ne": value.value}
                 else:
                     # Unknown operator, fall back to exact match
                     mongo_query[key] = value.value

--- a/campus/storage/query.py
+++ b/campus/storage/query.py
@@ -6,7 +6,7 @@ These operators enable more expressive queries while maintaining backward
 compatibility with simple exact-match queries.
 
 Example:
-    from campus.storage.query import gt, gte, lt, lte, between
+    from campus.storage.query import gt, gte, lt, lte, ne, between
 
     # Simple exact match (backward compatible)
     storage.get_matching({"user_id": "user_123"})
@@ -15,6 +15,7 @@ Example:
     storage.get_matching({"duration_ms": gt(1000)})
     storage.get_matching({"started_at": gte("2024-01-01")})
     storage.get_matching({"status_code": lt(500)})
+    storage.get_matching({"id": ne("@metadata")})
     storage.get_matching({"started_at": between("2024-01-01", "2024-12-31")})
 """
 
@@ -61,6 +62,14 @@ class lte(Operator):
 
     Example:
         {"retries": lte(3)}  # retries <= 3
+    """
+
+
+class ne(Operator):
+    """Not equal comparison.
+
+    Example:
+        {"id": ne("@metadata")}  # id != "@metadata"
     """
 
 

--- a/campus/storage/tables/backend/postgres.py
+++ b/campus/storage/tables/backend/postgres.py
@@ -34,7 +34,7 @@ from campus.common import devops, env
 from campus.common.utils import datacls
 from campus.model import InternalModel, Model, constraints
 from campus.storage import errors
-from campus.storage.query import gt, gte, is_operator, lt, lte
+from campus.storage.query import gt, gte, is_operator, lt, lte, ne
 
 from ..interface import PK, TableInterface
 
@@ -213,7 +213,7 @@ class PostgreSQLTable(TableInterface):
     def _build_where_clause(query: dict) -> tuple[str, list]:
         """Build WHERE clause from query dictionary.
 
-        Handles exact matches and comparison operators (gt, gte, lt, lte).
+        Handles exact matches and comparison operators (gt, gte, lt, lte, ne).
         """
         if not query:
             return "", []
@@ -226,16 +226,27 @@ class PostgreSQLTable(TableInterface):
                 # Handle comparison operators
                 if isinstance(value, gt):
                     conditions.append(f'"{key}" > %s')
+                    params.append(value.value)
                 elif isinstance(value, gte):
                     conditions.append(f'"{key}" >= %s')
+                    params.append(value.value)
                 elif isinstance(value, lt):
                     conditions.append(f'"{key}" < %s')
+                    params.append(value.value)
                 elif isinstance(value, lte):
                     conditions.append(f'"{key}" <= %s')
+                    params.append(value.value)
+                elif isinstance(value, ne):
+                    # Not equal: handle NULL values correctly using IS NOT NULL
+                    if value.value is None:
+                        conditions.append(f'"{key}" IS NOT NULL')
+                    else:
+                        conditions.append(f'"{key}" != %s')
+                        params.append(value.value)
                 else:
                     # Unknown operator, fall back to exact match
                     conditions.append(f'"{key}" = %s')
-                params.append(value.value)
+                    params.append(value.value)
             else:
                 # Exact match - handle NULL values correctly using IS NULL
                 if value is None:

--- a/campus/storage/tables/backend/sqlite.py
+++ b/campus/storage/tables/backend/sqlite.py
@@ -34,7 +34,7 @@ from campus.common import devops
 from campus.common.utils import datacls
 from campus.model import InternalModel, Model, constraints
 from campus.storage import errors as storage_errors
-from campus.storage.query import gt, gte, is_operator, lt, lte
+from campus.storage.query import gt, gte, is_operator, lt, lte, ne
 from ..interface import TableInterface, PK
 
 
@@ -359,7 +359,7 @@ class SQLiteTable(TableInterface):
     def _build_where_clause(query: dict[str, Any]) -> tuple[str, list]:
         """Build WHERE clause from query dictionary.
 
-        Handles exact matches and comparison operators (gt, gte, lt, lte, between).
+        Handles exact matches and comparison operators (gt, gte, lt, lte, ne, between).
         Uses ? placeholders for SQLite parameter binding.
         """
         if not query:
@@ -384,6 +384,13 @@ class SQLiteTable(TableInterface):
                 elif isinstance(value, lte):
                     conditions.append(f'"{key}" <= ?')
                     params.append(value.value)
+                elif isinstance(value, ne):
+                    # Not equal: handle NULL values correctly using IS NOT NULL
+                    if value.value is None:
+                        conditions.append(f'"{key}" IS NOT NULL')
+                    else:
+                        conditions.append(f'"{key}" != ?')
+                        params.append(value.value)
                 elif isinstance(value, between_op):
                     # BETWEEN operator: key >= min AND key <= max
                     min_val, max_val = value.value

--- a/tests/unit/storage/test_backends.py
+++ b/tests/unit/storage/test_backends.py
@@ -2,7 +2,7 @@
 """Test the new storage backends for Flask test client strategy."""
 
 import unittest
-from campus.storage import get_table, get_collection, gt, gte, lt, lte
+from campus.storage import get_table, get_collection, gt, gte, lt, lte, ne
 from campus.storage import errors as storage_errors
 from campus.common import env
 
@@ -128,6 +128,25 @@ class TestSQLiteBackend(unittest.TestCase):
         self.assertEqual(len(results), 2)
         for r in results:
             self.assertLessEqual(r["duration_ms"], 500)
+
+    def test_get_matching_with_ne_operator(self):
+        """get_matching() with ne (not equal) operator."""
+        results = self.traces_table.get_matching({"status_code": ne(200)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertNotEqual(r["status_code"], 200)
+        # Should return trace3 and trace4 with status_code 500
+        result_ids = {r["id"] for r in results}
+        self.assertEqual(result_ids, {"trace3", "trace4"})
+
+    def test_get_matching_with_ne_operator_string(self):
+        """get_matching() with ne operator on string field."""
+        results = self.traces_table.get_matching({"id": ne("trace1")})
+        self.assertEqual(len(results), 3)
+        for r in results:
+            self.assertNotEqual(r["id"], "trace1")
+        result_ids = {r["id"] for r in results}
+        self.assertEqual(result_ids, {"trace2", "trace3", "trace4"})
 
     def test_get_matching_with_multiple_operators(self):
         """get_matching() with multiple operator conditions (implicit AND)."""
@@ -492,6 +511,16 @@ class TestMemoryBackend(unittest.TestCase):
         self.assertEqual(len(results), 2)
         for r in results:
             self.assertLessEqual(r["value"], 500)
+
+    def test_get_matching_with_ne_operator(self):
+        """get_matching() with ne (not equal) operator."""
+        results = self.metrics_collection.get_matching({"score": ne(200)})
+        self.assertEqual(len(results), 2)
+        for r in results:
+            self.assertNotEqual(r["score"], 200)
+        # Should return metric3 and metric4 with score 500
+        result_ids = {r["id"] for r in results}
+        self.assertEqual(result_ids, {"metric3", "metric4"})
 
     def test_get_matching_with_multiple_operators(self):
         """get_matching() with multiple operator conditions (implicit AND)."""

--- a/tests/unit/storage/test_query_operators.py
+++ b/tests/unit/storage/test_query_operators.py
@@ -48,14 +48,23 @@ class TestQueryOperators(unittest.TestCase):
         self.assertEqual(op.value, 3)
         self.assertTrue(is_operator(op))
 
+    def test_ne_operator(self):
+        """ne operator stores value correctly."""
+        from campus.storage.query import ne, is_operator
+
+        op = ne("@metadata")
+        self.assertEqual(op.value, "@metadata")
+        self.assertTrue(is_operator(op))
+
     def test_is_operator_returns_true_for_operators(self):
         """is_operator returns True for all operator types."""
-        from campus.storage.query import gt, gte, lt, lte, is_operator
+        from campus.storage.query import gt, gte, lt, lte, ne, is_operator
 
         self.assertTrue(is_operator(gt(100)))
         self.assertTrue(is_operator(gte(100)))
         self.assertTrue(is_operator(lt(100)))
         self.assertTrue(is_operator(lte(100)))
+        self.assertTrue(is_operator(ne(100)))
 
     def test_is_operator_returns_false_for_non_operators(self):
         """is_operator returns False for regular values."""
@@ -85,7 +94,7 @@ class TestQueryOperators(unittest.TestCase):
 
     def test_operators_with_different_types(self):
         """Operators should work with various value types."""
-        from campus.storage.query import gt, lt, gte, lte, is_operator
+        from campus.storage.query import gt, lt, gte, lte, ne, is_operator
         from datetime import datetime
 
         # Integer
@@ -101,32 +110,39 @@ class TestQueryOperators(unittest.TestCase):
         dt = datetime(2024, 1, 1)
         self.assertTrue(is_operator(lte(dt)))
 
+        # String with ne
+        self.assertTrue(is_operator(ne("@metadata")))
+
     def test_operator_type_checking(self):
         """Operator instances are identified by their type."""
-        from campus.storage.query import gt, gte, lt, lte, is_operator, Operator
+        from campus.storage.query import gt, gte, lt, lte, ne, is_operator, Operator
 
         gt_op = gt(100)
         gte_op = gte(100)
         lt_op = lt(100)
         lte_op = lte(100)
+        ne_op = ne(100)
 
         # All are operators
         self.assertTrue(is_operator(gt_op))
         self.assertTrue(is_operator(gte_op))
         self.assertTrue(is_operator(lt_op))
         self.assertTrue(is_operator(lte_op))
+        self.assertTrue(is_operator(ne_op))
 
         # Each is a different type
         self.assertIsInstance(gt_op, gt)
         self.assertIsInstance(gte_op, gte)
         self.assertIsInstance(lt_op, lt)
         self.assertIsInstance(lte_op, lte)
+        self.assertIsInstance(ne_op, ne)
 
         # All inherit from Operator
         self.assertIsInstance(gt_op, Operator)
         self.assertIsInstance(gte_op, Operator)
         self.assertIsInstance(lt_op, Operator)
         self.assertIsInstance(lte_op, Operator)
+        self.assertIsInstance(ne_op, Operator)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add a new `ne` (not equal) query operator for filtering records where a field does not match a specific value. This is useful for excluding special records like metadata documents from query results.

## Changes
- Add `ne` operator class to `campus/storage/query.py`
- Export `ne` from `campus/storage/__init__.py`
- Add support in all storage backends:
  - MongoDB: translates to `{"$ne": value}`
  - SQLite: uses `!=` (or `IS NOT NULL` for None)
  - PostgreSQL: uses `!=` (or `IS NOT NULL` for None)
  - Memory: in-memory `!=` comparison
- Add unit tests and integration tests

## Example Usage
```python
from campus.storage import ne

# Exclude metadata documents
results = timetable_collection.get_matching({"id": ne("@metadata")})

# Exclude specific status codes
results = traces_table.get_matching({"status_code": ne(200)})
```

## Test plan
- [x] Unit tests pass for `ne` operator
- [x] Integration tests pass for SQLite backend
- [x] Integration tests pass for Memory backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)