### PR TITLE
Fix: Add missing __init__.py to campus.common.utils

### DIFF
--- a/campus/common/utils/__init__.py
+++ b/campus/common/utils/__init__.py
@@ -1,0 +1,8 @@
+"""campus.common.utils
+
+Utility functions for Campus.
+"""
+
+from . import url
+
+__all__ = ["url"]


### PR DESCRIPTION
## Summary
- Adds missing `__init__.py` to `campus/common/utils/` directory
- Fixes `ModuleNotFoundError: No module named 'campus.common.utils'`

## Root Cause
The `campus.common.errors.handlers` module imports `from campus.common.utils import url`, but the utils directory lacked an `__init__.py` file, causing Python to not recognize it as an importable package.

## Test plan
- [x] Import test passes: `from campus.common.utils import url`
- [x] No circular dependencies introduced (verified import chain)
- [ ] Run test suite to verify error handlers work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)