### PR TITLE
Improve device verification window close handling

### DIFF
--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -862,10 +862,14 @@ def device_verification(user_code: str | None = None):
 
                     if (seconds <= 0) {
                         clearInterval(window.deviceAuthCountdown);
-                        countdownText.textContent = 'Closing window...';
-                        setTimeout(function() {
+                        // Note: window.close() may not work due to browser security restrictions
+                        // Windows not opened by JavaScript cannot be closed programmatically
+                        countdownText.textContent = 'You can safely close this window and return to your CLI application.';
+                        try {
                             window.close();
-                        }, 500);
+                        } catch (e) {
+                            // Ignore errors - window will be closed manually by user
+                        }
                     }
                 }, 1000);
             }


### PR DESCRIPTION
## Summary
- Updates device verification countdown completion message
- Wraps `window.close()` in try-catch for graceful handling
- Informs users they can safely close the window manually

## Context
Browser security restrictions prevent programmatic closing of windows
that were not opened by JavaScript. This change improves UX by providing
clear guidance when the automatic close fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)