### PR TITLE
Add public client support for OAuth device auth flow

### DIFF
--- a/campus/auth/resources/client.py
+++ b/campus/auth/resources/client.py
@@ -29,8 +29,10 @@ def _from_record(
         ),
         name=record["name"],
         description=record["description"],
+        is_public=record.get("is_public", False),
+        redirect_uris=record.get("redirect_uris", []),
         permissions=permissions or {},
-        secret_hash=record["secret_hash"],
+        secret_hash=record.get("secret_hash"),
     )
 
 
@@ -103,20 +105,36 @@ class ClientsResource:
     def is_valid_credentials(
             self,
             client_id: schema.CampusID | str,
-            client_secret: str
+            client_secret: str | None = None
     ) -> bool:
         """Check if client credentials are valid.
 
         Args:
             client_id: The client identifier
-            client_secret: The client secret
+            client_secret: The client secret (optional for public clients)
         Returns:
             True if credentials are valid, False otherwise
         """
         client = self[schema.CampusID(client_id)].get()
+
+        # Public clients (CLI, mobile) are validated by client_id only
+        if client.is_public:
+            if client_secret is not None:
+                raise auth_errors.UnauthorizedClientError(
+                    "Public client should not provide a secret",
+                    client_id=client_id
+                )
+            return True
+
+        # Confidential clients must have a valid secret
         if not client.secret_hash:
             raise auth_errors.ServerError(
-                "Invalid configuration",
+                "Invalid configuration - confidential client missing secret_hash",
+                client_id=client_id
+            )
+        if client_secret is None:
+            raise auth_errors.UnauthorizedClientError(
+                "Confidential client requires a secret",
                 client_id=client_id
             )
         expected_hash = secret.hash_client_secret(
@@ -223,9 +241,17 @@ class ClientResource:
 
         Returns:
             The generated client secret
+
+        Raises:
+            auth_errors.InvalidRequestError: If client is public (no secret to revoke)
         """
         # Check if client exists first
-        self.get()
+        client = self.get()
+        if client.is_public:
+            raise auth_errors.InvalidRequestError(
+                "Public clients do not have a secret to revoke",
+                client_id=self.client_id
+            )
         new_secret = secret.generate_client_secret()
         secret_hash = secret.hash_client_secret(
             secret=new_secret,

--- a/campus/auth/routes/clients.py
+++ b/campus/auth/routes/clients.py
@@ -23,25 +23,41 @@ bp = flask.Blueprint('clients', __name__, url_prefix='/clients')
 
 @bp.post("/")
 @flask_campus.unpack_request
-def new(name: str, description: str) -> flask_campus.JsonResponse:
+def new(
+        name: str,
+        description: str,
+        is_public: bool = False,
+        redirect_uris: list[str] | None = None
+) -> flask_campus.JsonResponse:
     """Create a new vault client.
 
-    POST /client
+    POST /clients/
     Body: {
         "name": "Client Name",
-        "description": "Client description"
+        "description": "Client description",
+        "is_public": false,  # Optional: true for CLI/mobile apps
+        "redirect_uris": []  # Optional: OAuth redirect URIs
     }
 
     Returns: {
         "id": "client_abc123",
         "name": "Client Name",
         "description": "Client description",
+        "is_public": false,
+        "redirect_uris": [],
         "created_at": "2025-07-20T10:30:00Z"
     }
+
+    Public clients (is_public=true) don't have a client_secret and are used
+    for CLI, mobile apps, and native applications that cannot securely store
+    credentials per RFC 6749 Section 2.1.
     """
-    # Note that no client_secret is generated here
-    # Apps are expected to generate the secret separately
-    client = client_resource.new(name=name, description=description)
+    client = client_resource.new(
+        name=name,
+        description=description,
+        is_public=is_public,
+        redirect_uris=redirect_uris or []
+    )
     get_yapper().emit('campus.clients.create', {"client_id": client.id})
     return client.to_resource(), 200
 
@@ -124,27 +140,35 @@ def revoke_client(client_id: schema.CampusID) -> flask_campus.JsonResponse:
 def update_client(
         client_id: schema.CampusID,
         name: str | None = None,
-        description: str | None = None
+        description: str | None = None,
+        redirect_uris: list[str] | None = None
 ) -> flask_campus.JsonResponse:
     """Update a client's details.
 
     PATCH /clients/{client_id}
     Body: {
         "name": "New Client Name",
-        "description": "New description"
+        "description": "New description",
+        "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob"]  # Optional
     }
     Returns: {
         "id": "client_abc123",
         "name": "New Client Name",
         "description": "New description",
+        "is_public": false,
+        "redirect_uris": [],
         "created_at": "2025-07-20T10:30:00Z"
     }
+
+    Note: is_public cannot be changed after client creation.
     """
     updates = {}
     if name is not None:
         updates["name"] = name
     if description is not None:
         updates["description"] = description
+    if redirect_uris is not None:
+        updates["redirect_uris"] = redirect_uris
     if not updates:
         raise api_errors.InvalidRequestError(
             "No updates provided",

--- a/campus/auth/routes/oauth.py
+++ b/campus/auth/routes/oauth.py
@@ -14,8 +14,8 @@ import campus.config
 import campus.model
 from campus import flask_campus
 from campus.common import schema
-from campus.common.errors import api_errors, auth_errors, token_errors
-from campus.common.utils import uid, secret
+from campus.common.errors import api_errors, token_errors
+from campus.common.utils import secret
 
 from .. import get_yapper
 from ..resources import device_code as device_code_resource
@@ -87,20 +87,18 @@ def device_authorize(
     Reference: https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
     """
     # Validate the client
-    # "guest" is a special public client type for CLI/device apps
-    # It doesn't exist in the database and has no inherent permissions
-    # All access comes from the user's credentials during the OAuth flow
-    if client_id == campus.config.PUBLIC_OAUTH_CLIENT_ID:
-        # Skip database validation for public guest clients
-        pass
-    else:
-        # For regular clients, verify they exist in the database
-        try:
-            client_resource[client_id].get()
-        except api_errors.NotFoundError:
+    # All clients (public or confidential) must exist in the database
+    try:
+        client = client_resource[client_id].get()
+        # Verify public client configuration
+        if client.is_public and client.secret_hash:
             raise token_errors.InvalidClientError(
-                "Invalid client_id"
+                "Invalid client configuration - public client should not have a secret"
             )
+    except api_errors.NotFoundError:
+        raise token_errors.InvalidClientError(
+            "Invalid client_id"
+        )
 
     # Create device code
     device_code = device_code_resource.create(
@@ -191,14 +189,18 @@ def token(
     }
     """
     # Validate the client
-    # "guest" is a special public client type - no database validation needed
-    if client_id != campus.config.PUBLIC_OAUTH_CLIENT_ID:
-        try:
-            client_resource[client_id].get()
-        except api_errors.NotFoundError:
+    # All clients (public or confidential) must exist in the database
+    try:
+        client = client_resource[client_id].get()
+        # Verify public client configuration
+        if client.is_public and client.secret_hash:
             raise token_errors.InvalidClientError(
-                "Invalid client_id"
+                "Invalid client configuration - public client should not have a secret"
             )
+    except api_errors.NotFoundError:
+        raise token_errors.InvalidClientError(
+            "Invalid client_id"
+        )
 
     # Route to appropriate handler based on grant_type
     if grant_type == "urn:ietf:params:oauth:grant-type:device_code":

--- a/campus/model/client.py
+++ b/campus/model/client.py
@@ -15,7 +15,16 @@ from . import constraints
 
 @dataclass(eq=False, kw_only=True)
 class Client(Model):
-    """Represents a Campus client application."""
+    """Represents a Campus client application.
+
+    Clients can be either:
+    - Confidential: Have a client_secret and can securely store credentials
+    - Public: No client_secret (CLI, mobile apps, native applications)
+
+    Per RFC 6749 Section 2.1:
+    "Public clients are client applications incapable of keeping the
+    client password confidential."
+    """
     id: schema.CampusID = field(default_factory=(
         lambda: uid.generate_category_uid("client", length=8)
     ))
@@ -25,12 +34,23 @@ class Client(Model):
         "mutable": True,
     })
     description: str = field(metadata={"mutable": True})
+    # Mark public clients (no secret required) - CLI, mobile apps, native applications
+    is_public: bool = field(
+        default=False,
+        metadata={"mutable": False}
+    )
+    # OAuth redirect URIs for public clients (e.g., "urn:ietf:wg:oauth:2.0:oob")
+    redirect_uris: list[str] = field(
+        default_factory=list,
+        metadata={"mutable": True}
+    )
     # permissions are stored in a separate table
     permissions: dict[str, int] = field(
         default_factory=dict,
         metadata={"storage": False}
     )
     # secret_hash should not be included in API responses
+    # For public clients, this is None
     secret_hash: str | None = field(
         default=None,
         repr=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -84,6 +84,9 @@ def init():
     # Grant the test client full access to the 'vault' label
     client_resource.access.grant("vault", ClientAccess.ALL)
 
+    # Ensure the public OAuth client exists for device auth flow tests
+    ensure_public_oauth_client()
+
 
 def give_vault_access(
         label: str,
@@ -143,3 +146,44 @@ def give_vault_access(
             access_value += ClientAccess.DELETE
 
     client_resource.access.grant(label, access_value)
+
+
+def ensure_public_oauth_client():
+    """Ensure the public OAuth client for CLI/device apps exists.
+
+    Creates the 'guest' public client if it doesn't exist.
+    This client is used for OAuth 2.0 Device Authorization Flow (RFC 8628).
+
+    Public clients have no client_secret and are used by CLI, mobile apps,
+    and native applications that cannot securely store credentials.
+
+    The client_id is 'guest' as defined in campus.config.PUBLIC_OAUTH_CLIENT_ID.
+
+    Prerequisites:
+        - ENV must be 'testing'
+        - Storage tables must be initialized
+    """
+    from campus.auth import resources as auth_resources
+    from campus.auth.resources.client import client_storage
+    from campus.common import schema
+    import campus.config
+
+    require.require_env("testing")
+
+    # Check if public client already exists
+    client_id = schema.CampusID(campus.config.PUBLIC_OAUTH_CLIENT_ID)
+    try:
+        client_storage.get_by_id(client_id)
+        return  # Already exists
+    except Exception:
+        pass  # Client doesn't exist, create it
+
+    # Create the public client
+    auth_resources.client.new(
+        id=client_id,
+        name="Public CLI Client",
+        description="Public OAuth client for CLI and device applications",
+        is_public=True,
+        redirect_uris=["urn:ietf:wg:oauth:2.0:oob"],  # RFC 8628 out-of-band URI
+        secret_hash=None  # Public clients have no secret
+    )

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+# tests.integration

--- a/tests/integration/auth/__init__.py
+++ b/tests/integration/auth/__init__.py
@@ -1,1 +1,1 @@
-# Integration tests for campus.auth package
+# tests.integration.auth


### PR DESCRIPTION
This adds support for public OAuth clients (CLI, mobile apps, native
applications) per RFC 6749 Section 2.1, which cannot securely store
client credentials.

## Problem
The CLI uses `client_id="guest"` for OAuth device authorization flow, but
this client doesn't exist in the database. The code treats "guest" as a
special case that skips validation, but when tokens are issued with
`client_id="guest"`, subsequent authenticated requests fail with
"Client 'guest' not found".

## Solution
Add proper `is_public` field to the `Client` model and seed a real public
client entry for "guest".

## Changes
- Add `is_public: bool` and `redirect_uris: list[str]` fields to Client model
- Update client validation to skip secret check for public clients
- Update OAuth routes to validate all clients uniformly (remove "guest" special case)
- Update HTTP API to accept `is_public` and `redirect_uris` in client creation/updates
- Add `ensure_public_oauth_client()` to create "guest" public client in tests

## RFC References
- RFC 6749 Section 2.1: Client Types (public vs confidential)
- RFC 8628: Device Authorization Flow

## Testing
- All 11 OAuth integration tests pass
- Client contract tests pass
- Public client is automatically created in test fixtures

Fixes #603

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>